### PR TITLE
feat: writtingpage 폰트 크기 조절 기능 및 textarea 크기 고정

### DIFF
--- a/src/Pages/WrittingPage/WrittingPage.tsx
+++ b/src/Pages/WrittingPage/WrittingPage.tsx
@@ -1,17 +1,25 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
 import { textState } from '../recoil';
 import * as S from './Wrtiting.styled';
 
 export default function WrittingPage() {
-  const [text,setText] = useRecoilState(textState)
+  const [text, setText] = useRecoilState(textState)
+  const [font, setFont] = useState()
+  const [size, setSize] = useState('12')
 
   return (
     <S.WritingDiv>
       <h1>편지에 작성할 편지내용을 입력하는 단계입니다.</h1>
+      <p>원하시는 글자 폰트를 선택해주세요</p>
+      <button>적용</button>
+      <p>원하시는 글자 크기를 선택해주세요</p>
+      <input type="text" value={size} onChange={e => setSize(e.target.value)} />
+      <button onClick={() => setSize(size)}>적용</button>
+
       <S.WritingForm>
-        <S.WritingArea name="letter" cols={50} rows={30} value={text} onChange={e => setText(e.target.value)}></S.WritingArea>
+        <S.WritingArea name="letter" cols={100} rows={30} style={{ fontSize: `${size}px` }} value={text} onChange={e => setText(e.target.value)}></S.WritingArea>
       </S.WritingForm>
 
       <Link to="/info">

--- a/src/Pages/WrittingPage/Wrtiting.styled.ts
+++ b/src/Pages/WrittingPage/Wrtiting.styled.ts
@@ -7,10 +7,16 @@ export const WritingDiv = styled.div`
 `;
 
 export const WritingForm = styled.form`
-  width: auto;
   margin-top: 40px;
 `;
 
 export const WritingArea = styled.textarea`
+  &:focus {
+    outline: none;
+  }
+  max-width: 400px;
+  padding: 10px;
+  resize: none;
   margin-bottom: 20px;
+  border-radius: 10px;
 `;


### PR DESCRIPTION
# 1.  writtingpage 폰트 크기 조절 기능 추가
- 폰트 크기를 조절하여 작성 text 작성 가능
- 크기 조절은 input 태그를 통해 변경 가능
- default 값은 12px로 설정

# 2. textarea 크기 고정
- textarea의 크기를 max-width:300px로 고정
- 추후에 반응형으로 수정 할 것