### PR TITLE
feat: recoil-persist 추가 및 font size, family의 recoil화

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "react-router-dom": "^6.17.0",
         "react-scripts": "5.0.1",
         "recoil": "^0.7.7",
+        "recoil-persist": "^5.1.0",
         "styled-components": "^6.1.0",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
@@ -14666,6 +14667,14 @@
         "react-native": {
           "optional": true
         }
+      }
+    },
+    "node_modules/recoil-persist": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/recoil-persist/-/recoil-persist-5.1.0.tgz",
+      "integrity": "sha512-sew4k3uBVJjRWKCSFuBw07Y1p1pBOb0UxLJPxn4G2bX/9xNj+r2xlqYy/BRfyofR/ANfqBU04MIvulppU4ZC0w==",
+      "peerDependencies": {
+        "recoil": "^0.7.2"
       }
     },
     "node_modules/recursive-readdir": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "react-router-dom": "^6.17.0",
     "react-scripts": "5.0.1",
     "recoil": "^0.7.7",
+    "recoil-persist": "^5.1.0",
     "styled-components": "^6.1.0",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"

--- a/src/Pages/TestPage/TestPage.tsx
+++ b/src/Pages/TestPage/TestPage.tsx
@@ -1,17 +1,23 @@
 import React from 'react';
-import { userState, nameState, textState } from '../recoil';
+import { userState, nameState, textState, fontState, sizeState } from '../recoil';
 import { useRecoilValue } from 'recoil';
 
 export default function TestPage() {
   const user = useRecoilValue(userState);
   const name = useRecoilValue(nameState);
-  const text = useRecoilValue(textState)
+  const text = useRecoilValue(textState);
+  const font = useRecoilValue(fontState);
+  const size = useRecoilValue(sizeState);
 
   return (
     <div>
+      <link
+        href={`https://fonts.googleapis.com/css?family=${font}`}
+        rel="stylesheet"
+      />
       <p> 당신의 이름 : {user}</p>
       <p>편지를 받을 분의 이름: {name}</p>
-      <p>편지 내용 : {text}</p>
+      <p>편지 내용 : <p style={{ fontSize: `${size}px`, fontFamily: font }}>{text}</p></p>
     </div>
   );
 }

--- a/src/Pages/WrittingPage/WrittingPage.tsx
+++ b/src/Pages/WrittingPage/WrittingPage.tsx
@@ -1,13 +1,13 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
-import { textState } from '../recoil';
+import { textState, fontState, sizeState } from '../recoil';
 import * as S from './Wrtiting.styled';
 
 export default function WrittingPage() {
   const [text, setText] = useRecoilState(textState)
-  const [font, setFont] = useState<string>('Arial')
-  const [size, setSize] = useState<string>('12')
+  const [font, setFont] = useRecoilState<string>(fontState)
+  const [size, setSize] = useRecoilState<string>(sizeState)
 
   const handleFontChange = (e: React.ChangeEvent<HTMLSelectElement>) => { setFont(e.target.value) }
   const handleSizeChange = (e: React.ChangeEvent<HTMLSelectElement>) => { setSize(e.target.value) }

--- a/src/Pages/recoil.tsx
+++ b/src/Pages/recoil.tsx
@@ -1,16 +1,34 @@
 import { atom } from 'recoil';
+import { recoilPersist } from 'recoil-persist';
+
+const { persistAtom } = recoilPersist();
 
 export const userState = atom<string>({
   key: 'userState',
   default: '',
+  effects_UNSTABLE: [persistAtom]
 });
 
 export const nameState = atom<string>({
   key: 'nameState',
   default: '',
+  effects_UNSTABLE: [persistAtom]
 });
 
 export const textState = atom<string | number>({
-  key: 'textStat',
+  key: 'textState',
   default: '',
+  effects_UNSTABLE: [persistAtom]
+})
+
+export const fontState = atom<string>({
+  key: 'fontState',
+  default: 'Arial',
+  effects_UNSTABLE: [persistAtom]
+})
+
+export const sizeState = atom<string>({
+  key: 'sizeState',
+  default: '12',
+  effects_UNSTABLE: [persistAtom]
 })


### PR DESCRIPTION
# 1.  recoil-persist 라이브러리를 추가했습니다.
- 어느 컴퍼넌트에서 새로고침을 하더라도 reocoil안에 있는 데이터 값이 변하지 않습니다.

# 2. writtingpage 컴퍼넌트의 font size와 font family의 상태를 recoil에서 관리할 수 있도록 설정했습니다.