### PR TITLE
feat: BackgroundPage 생성 및 페이지 배경 선택 기능 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@types/react": "^18.2.28",
         "@types/react-dom": "^18.2.13",
         "react": "^18.2.0",
+        "react-colorful": "^5.6.1",
         "react-dom": "^18.2.0",
         "react-responsive-carousel": "^3.2.23",
         "react-router-dom": "^6.17.0",
@@ -14374,6 +14375,15 @@
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
       "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+    },
+    "node_modules/react-colorful": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.6.1.tgz",
+      "integrity": "sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
     },
     "node_modules/react-dev-utils": {
       "version": "12.0.1",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@types/react": "^18.2.28",
     "@types/react-dom": "^18.2.13",
     "react": "^18.2.0",
+    "react-colorful": "^5.6.1",
     "react-dom": "^18.2.0",
     "react-responsive-carousel": "^3.2.23",
     "react-router-dom": "^6.17.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import InfoPage from './Pages/InfoPage/InfoPage';
 import WrittingPage from './Pages/WrittingPage/WrittingPage';
 import TestPage from './Pages/TestPage/TestPage';
 import ImagePage from './Pages/ImagePage/ImagePage';
+import BackgroundPage from './Pages/BackgroundPage/BackgroundPage';
 
 function App() {
   return (
@@ -16,6 +17,7 @@ function App() {
           <Route path="/write" element={<WrittingPage />}></Route>
           <Route path="/test" element={<TestPage />}></Route>
           <Route path="/image" element={<ImagePage />}></Route>
+          <Route path="/background" element={<BackgroundPage />}></Route>
         </Routes>
       </BrowserRouter>
     </div>

--- a/src/Pages/BackgroundPage/BackgroundPage.styled.ts
+++ b/src/Pages/BackgroundPage/BackgroundPage.styled.ts
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+
+export const backgroundDiv = styled.div`
+  max-width: 800px;
+  margin: auto;
+  margin-top: 80px;
+
+  text-align: center;
+`;

--- a/src/Pages/BackgroundPage/BackgroundPage.tsx
+++ b/src/Pages/BackgroundPage/BackgroundPage.tsx
@@ -1,0 +1,56 @@
+import React, { useState, useEffect } from 'react'
+import { HexColorPicker } from 'react-colorful'
+import { createGlobalStyle } from 'styled-components'
+import { Link } from 'react-router-dom';
+import * as S from './BackgroundPage.styled'
+
+
+export default function BackgroundPage() {
+  const [color, setColor] = useState("#aabbcc");
+  const [colorArray, setColorArray] = useState<string[]>(['#FFC0CB', '#FFA500'])
+  const [selectImage, setSelectImage] = useState<string | null>(null);
+
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      const imageUrl = URL.createObjectURL(file);
+      setSelectImage(imageUrl);
+    }
+  }
+
+  const GlobalStyles = createGlobalStyle`
+  body {
+    height: 100vh;
+    background: linear-gradient(to bottom, ${colorArray[0]} , ${colorArray[1]});
+  }`
+
+
+  const handleColorArray = () => {
+    const pickedColor = color
+    setColorArray([...colorArray, pickedColor].slice(1))
+  }
+  const reverseColorArray = () => {
+    setColorArray([...colorArray].reverse())
+  }
+
+  return (
+    <div>
+      <GlobalStyles />
+      <S.backgroundDiv >
+        <h1>편지의 배경을 선택하는 페이지 입니다.</h1>
+        <input type="file" accept='image/*' onChange={handleImageChange} />
+        <HexColorPicker color={color} onChange={setColor} />
+        <button onClick={handleColorArray}>+</button>
+        <button onClick={reverseColorArray}>@</button>
+
+        <Link to="/image">
+          <button>이전</button>
+        </Link>
+        <Link to="/test">
+          <button>다음</button>
+        </Link>
+
+      </S.backgroundDiv>
+    </div>
+  )
+}

--- a/src/Pages/ImagePage/ImagePage.tsx
+++ b/src/Pages/ImagePage/ImagePage.tsx
@@ -43,7 +43,7 @@ export default function ImagePage() {
       <Link to="/write">
         <button>이전</button>
       </Link>
-      <Link to="/test">
+      <Link to="/background">
         <button>다음</button>
       </Link>
 


### PR DESCRIPTION
# 1. 웹 페이지의 배경 색을 커스텀할 수 있는 BackgroundPage 생성했습니다.
- react-colorful 라이브러리를 사용하여 다양한 색상을 자유롭게 선택할 수 있는 팔레트를 추가했습니다.
- 백그라운드 색상은 그라데이션을 넣을 수 있도록 설정했습니다.
- 원하는 색상을 선택하여 '+' 버튼을 누르면 기존의 두가지 색 중 위의 색이 제거 되고 새로운 색이 하단으로 넘어가는 로직을 구현했습니다.
- 단색을 원하는 경우에는 같은 색을 두번 더하면 됩니다.
- 색상의 반전을 원하는 경우에는 '@'버튼을 클릭하면 됩니다.
- 웹페이지의 배경은 이미지보다 그라데이션 혹은 단색의 색상으로 커스텀하는 것이 좋을 것이라 판단하여 배경을 이미지로 하는 기능을 넣지 않았습니다.
- 편지의 내용이 들어갈 div 배경은 색상이 아닌 5개의 별도의 이미지를 사용하여 선택할 수 있도록 표현할 예정입니다.