### PR TITLE
feat: 페이지 랜더링 시 스크롤을 맨 위로 올려주는 기능 추가 및 Button 공용 컴퍼넌트 CSS 변경

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import BgmPage from './Pages/BgmPage/BgmPage';
 import { useRecoilValue } from 'recoil';
 import { backgroundState } from './Pages/recoil';
 import { createGlobalStyle } from 'styled-components'
+import ScrollToTop from './Common/ScrollToTop/ScrollToTop';
 
 
 function App() {
@@ -41,7 +42,8 @@ function App() {
   return (
     <div>
       <GlobalStyles />
-      <BrowserRouter basename={process.env.PUBLIC_URL}>
+      <BrowserRouter>
+        <ScrollToTop />
         <Routes>
           <Route path="/" element={<FirstPage />}></Route>
           <Route path="/info" element={<InfoPage />}></Route>

--- a/src/Common/Button/Button.styled.ts
+++ b/src/Common/Button/Button.styled.ts
@@ -1,3 +1,9 @@
 import styled from 'styled-components';
 
-export const btnSection = styled.section``;
+export const btnSection = styled.section`
+  margin-top: 40px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+`;

--- a/src/Common/ScrollToTop/ScrollToTop.tsx
+++ b/src/Common/ScrollToTop/ScrollToTop.tsx
@@ -1,0 +1,12 @@
+import React, { useEffect } from 'react'
+import { useLocation } from 'react-router-dom'
+
+export default function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0)
+  }, [pathname])
+
+  return null
+}


### PR DESCRIPTION
# 1. 페이지 랜더링 시 화면을 맨 위 상단으로 고정되는 기능을 추가했습니다.
- 페이지를 이동시, 이전 페이지의 스크롤 위치에 랜더링이 되는 버그가 있었습니다.
- 공용 컴퍼넌트에 ScrollToTop 컴퍼넌트를 추가하여 useEffect로 랜더링 시 페이지 상단으로 고정되는 기능으로 해결했습니다.

# 2. 페이지 이동 버튼의 UI를 개선했습니다.
- 페이지의 content와 붙어있는 부분을 margin-top으로 가시성을 키웠습니다.
- 나란히 나열된 이동버튼의 사이에 gap을 부여했습니다.