### PR TITLE
feat: CheckPage에서 false 답변시 true로 답변할 수 있는 버튼 추가

### DIFF
--- a/src/Pages/CheckPage/CheckPage.styled.ts
+++ b/src/Pages/CheckPage/CheckPage.styled.ts
@@ -29,3 +29,23 @@ export const textSection = styled.section`
 export const guideImg = styled.img`
   transition: opacity 1s ease-in-out;
 `;
+
+export const BtnSection = styled.section`
+  margin-top: 20px;
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+`;
+
+export const falseText = styled.section`
+  max-width: 300px;
+  margin: auto;
+  border-radius: 10px;
+  border: 1px solid transparent;
+  background-color: #ffff;
+`;
+
+export const answerAgian = styled.button`
+  border: 0;
+  background-color: transparent;
+`;

--- a/src/Pages/CheckPage/CheckPage.tsx
+++ b/src/Pages/CheckPage/CheckPage.tsx
@@ -19,6 +19,7 @@ export default function CheckPage() {
   const handleTrue = () => {
     setDefaultImg(guide2)
     setDefaultText(false)
+    setFalseText(false)
     setTrueText(true)
     setBtnAble('auto')
   }
@@ -54,11 +55,17 @@ export default function CheckPage() {
         <S.guideImg src={defaultImg} alt="" />
       </Link>
 
+      {falseText &&
+        <S.falseText>
+          <S.answerAgian onClick={handleTrue}>생각해보니 맞는 것 같아!</S.answerAgian>
+        </S.falseText>
+      }
+
       {defaultText &&
-        <section>
+        <S.BtnSection>
           <button onClick={handleTrue}>맞아</button>
           <button onClick={handleFalse}>...아닌데?</button>
-        </section>
+        </S.BtnSection>
       }
 
     </S.checkDiv>


### PR DESCRIPTION
# 1. CheckPage에서 false 답변시 true로 답변할 수 있는 버튼을 추가했습니다.
- CheckPage에서 '아닌데' 버튼을 누르고(false로 답변) 다시 선택하는 화면으로 가기 위해서는 새로고침을 해야했습니다.
- 본 프로젝트에서 새로고침시 이미지 데이터가 렌더링 되지 않는 오류가 있기 때문에, 최대한 새로고침을 유도하지 않는 방면으로 코드를 짜야했습니다.
- 따라서, '맞아' 버튼을 누를 수 있는(true로 답변) 기능을 추가하여 본 문제를 우회하여 해결했습니다.
- 다만, 새로고침시 이미지가 렌더링 되지 않는 버그는 빠른 시일내에 수정할 예정입니다.