### PR TITLE
feat: 정보 페이지 및 편지 작성 페이지에 비어있는 값 전송 방지 기능 추가

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -22,6 +22,5 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
-    <script src="/static/js/bundle.js"></script>
   </body>
 </html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ function App() {
     padding: 0;
     width: 100%;
     height: 100%;
+    word-break: keep-all;
   }
 
   body::before {

--- a/src/Common/Button/Button.tsx
+++ b/src/Common/Button/Button.tsx
@@ -5,7 +5,7 @@ import * as S from './Button.styled'
 
 interface ButtonProps {
   previousLink: string;
-  nextLink: string;
+  nextLink: string | boolean | (() => void);
 }
 
 const Button: React.FC<ButtonProps> = (props) => {
@@ -16,9 +16,17 @@ const Button: React.FC<ButtonProps> = (props) => {
           <button>이전</button>
         </Link>
 
-        <Link to={props.nextLink}>
-          <button>다음</button>
-        </Link>
+        {typeof props.nextLink === 'string' ? (
+          <Link to={props.nextLink}>
+            <button>다음</button>
+          </Link>
+        ) : typeof props.nextLink === 'boolean' ? (
+          props.nextLink ? (
+            <button>다음</button>
+          ) : null
+        ) : typeof props.nextLink === 'function' ? (
+          <button onClick={props.nextLink}>다음</button>
+        ) : null}
       </S.btnSection>
     </div>
   );

--- a/src/Pages/CheckPage/CheckPage.tsx
+++ b/src/Pages/CheckPage/CheckPage.tsx
@@ -35,7 +35,7 @@ export default function CheckPage() {
     <S.checkDiv>
       {defaultText &&
         <S.textSection>
-          <p>안녕하세요, {name}! {user}님으로 부터 편지가 도착했습니다.</p>
+          <p>안녕하세요, {name}님!!  {user}님으로 부터 편지가 도착했습니다.</p>
           <p>{name}님 본인이 맞으실까요??</p>
         </S.textSection>
       }

--- a/src/Pages/InfoPage/InfoPage.tsx
+++ b/src/Pages/InfoPage/InfoPage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
 import { userState, nameState } from '../recoil';
 import Button from '../../Common/Button/Button'
@@ -8,6 +8,17 @@ import * as S from './InfoPage.styled';
 export default function InfoPage() {
   const [user, setUser] = useRecoilState(userState);
   const [name, setName] = useRecoilState(nameState);
+  const navigate = useNavigate()
+
+  const handleEmty = () => {
+    if (user.toString().trim().length === 0) {
+      alert("당신의 성함을 입력해주세요!")
+    } else if (name.toString().trim().length === 0) {
+      alert("편지를 받을 분의 성함을 입력해주세요!")
+    } else {
+      navigate('/write')
+    }
+  }
 
   return (
     <S.InfoDiv>
@@ -27,7 +38,7 @@ export default function InfoPage() {
         />
       </form>
 
-      <Button previousLink='/background' nextLink='/write' />
+      <Button previousLink='/background' nextLink={handleEmty} />
     </S.InfoDiv>
   );
 }

--- a/src/Pages/TestPage/TestPage.styled.ts
+++ b/src/Pages/TestPage/TestPage.styled.ts
@@ -11,12 +11,12 @@ export const testDiv = styled.div`
 export const testSection = styled.section`
   position: relative;
   max-width: 400px;
-  /* height: 400px; */
   margin: auto;
   justify-content: center;
   margin-top: 20px;
   border-radius: 10px;
   background-size: contain;
+  background-color: #ffff;
 
   @media (max-width: 400px) {
     max-width: 300px;

--- a/src/Pages/WrittingPage/WrittingPage.tsx
+++ b/src/Pages/WrittingPage/WrittingPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
 import { textState, fontState, sizeState, textBackState } from '../recoil';
 import Button from '../../Common/Button/Button'
@@ -7,14 +7,12 @@ import * as S from './Wrtiting.styled';
 import { img1, img2, img3, img4, img5 } from '../../img/img';
 
 
-
-
-
 export default function WrittingPage() {
   const [text, setText] = useRecoilState(textState)
   const [font, setFont] = useRecoilState<string>(fontState)
   const [size, setSize] = useRecoilState<string>(sizeState)
   const [selectImage, setSelectImage] = useRecoilState<string>(textBackState);
+  const navigate = useNavigate()
 
   const handleFontChange = (e: React.ChangeEvent<HTMLSelectElement>) => { setFont(e.target.value) }
   const handleSizeChange = (e: React.ChangeEvent<HTMLSelectElement>) => { setSize(e.target.value) }
@@ -27,7 +25,7 @@ export default function WrittingPage() {
     if (text.toString().trim().length === 0) {
       alert("편지에 아무것도 작성하지 않으셨습니다.")
     } else {
-      { `/image` }
+      navigate('/image')
     }
   }
 


### PR DESCRIPTION
# 1. 정보 페이지와 편지 작성 페이지에 content가 비어있는 경우, 다음 페이지로 넘어가지 않고 경고 문구를 보여주는 기능을 추가했습니다.
- 해당 페이지들에 비어있는 값을 보내면, 편지의 기능을 하지 않는 것이기에 내용을 반드시 작성하도록 설정했습니다.
- 버튼 공용 컴퍼넌트의 nextLink props에 타입의 분기를 부여하여 경우에 따라 Link를 제공하거나, null 값을 주는 방식으로 처리했습니다.
- 경고문구는 alert로 처리 했으나, 추후에 팝업 창으로 수정할 계획입니다.

# 2. 기타 UI 개선 및 불필요한 코드 제거했습니다.
- 본 프로젝트의 주 타켓층이 한국인이라는 점을 감안하여, GlobalStyle에 word-break 속성값을 keep-all로 설정했습니다.
- 편지자 배경을 설정하지 않는 경우, 바탕을 흰색으로 처리하도록 설정했습니다.
