### PR TITLE
feat: BgmPage내 모바일 영상 링크에서 영상ID 추출 기능 추가 및 ID 추출 가이드라인 추가

### DIFF
--- a/src/Pages/BgmPage/BgmPage.styled.ts
+++ b/src/Pages/BgmPage/BgmPage.styled.ts
@@ -1,5 +1,29 @@
 import { styled } from 'styled-components';
 
+export const bgmGuide = styled.div`
+  max-width: 400px;
+  margin: auto;
+  margin-top: 20px;
+  margin-bottom: 20px;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid black;
+`;
+
+export const pcGuide = styled.section`
+  width: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+`;
+
+export const mobileGuide = styled.section`
+  width: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+`;
+
 export const bgmDiv = styled.div`
   width: auto;
   margin-top: 80px;

--- a/src/Pages/BgmPage/BgmPage.tsx
+++ b/src/Pages/BgmPage/BgmPage.tsx
@@ -11,9 +11,23 @@ export default function BgmPage() {
   const [videoId, setVideoId] = useRecoilState(bgmState)
   const [inputValue, setInputValue] = useState('');
 
+  const extractVideoId = (url: string): string | null => {
+    const shortUrlMatch = url.match(/youtu\.be\/([^?]+)/)
+    if (shortUrlMatch) {
+      return shortUrlMatch[1];
+    }
+
+    const longUrlMatch = url.match(/[?&]v=([^&]+)/);
+    if (longUrlMatch) {
+      return longUrlMatch[1];
+    }
+
+    return null;
+  }
+
+
   const handleVideoId = () => {
-    const url = new URL(inputValue);
-    const videoID = url.searchParams.get('v');
+    const videoID = extractVideoId(inputValue)
     if (videoID !== null) {
       setVideoId(videoID);
     } else {
@@ -29,6 +43,16 @@ export default function BgmPage() {
   return (
     <S.bgmDiv>
       <h1>원하는 유튜브 bgm ID를 입력하는 페이지 입니다.</h1>
+      <S.bgmGuide>
+        <S.pcGuide>
+          <h2>1. PC버전으로 bgmID 입력하는 방법</h2>
+          <p>페이지 상단에 있는 페이지 주소(URL)을 복사해서 입력란에 붙여주세요.</p>
+        </S.pcGuide>
+        <S.mobileGuide>
+          <h2>2. 모바일 버전으로 bgmID입력하는 방법</h2>
+          <p>영상 하단의 공유 버튼을 클릭한 후, 링크복사를 한 뒤, 입력란에 붙여주세요.</p>
+        </S.mobileGuide>
+      </S.bgmGuide>
       <YouTube videoId={videoId}
         opts={{
           width: '300',


### PR DESCRIPTION
# 1. 유튜브 모바일 버전의 URL 주소를 입력하여 영상 ID를 추출할 수 있도록 개선했습니다.
- 이전에는 pc버전의 URL 주소만 영상ID를 추출할 수 있게 작성되어 모바일 사용자에게 강제로 pc버전의 유튜브를 사용해야하는 불편사항이 있었습니다.
- 이를 해결하고자 정규표현식을 사용하여 모바일 유튜브에서 복사한 링크도 입력란에 넣어 영상의 ID를 추출할 수 있도록 개선했습니다.

# 2. 영상 ID 추출 가이드라인을 추가 했습니다.
- 본 프로젝트는 전연령의 고객을 대상으로 하기에, 업로드를 희망하는 영상의 주소를 복사하는 방법을 모르는 시니어 고객을 위한 가이드라인을 추가했습니다.
- 현재는 아웃라인만 잡혀있으며, 상세한 가이드 추가 및 UI는 추후에 개선할 예정입니다.