### PR TITLE
feat: 공용 컴퍼넌트에 guideSection 컴퍼넌트 추가

### DIFF
--- a/src/Common/GuideSection/GuideSection.styled.ts
+++ b/src/Common/GuideSection/GuideSection.styled.ts
@@ -1,0 +1,26 @@
+import { styled } from 'styled-components';
+import { back } from '../../img/img';
+
+export const guideDiv = styled.div`
+  max-width: 400px;
+  margin: auto;
+  margin-top: 20px;
+  margin-bottom: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  border-radius: 10px;
+  background-image: url(${back});
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: cover;
+`;
+
+export const guideSection = styled.section`
+  width: auto;
+  margin-bottom: 10px;
+`;
+
+export const guideTitle = styled.h2`
+  margin: 0;
+`;

--- a/src/Common/GuideSection/GuideSection.tsx
+++ b/src/Common/GuideSection/GuideSection.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import * as S from './GuideSection.styled'
+
+interface GuideProps {
+  title: string;
+  step1: string;
+  step2: string | null
+  step3: string | null
+}
+
+export default function GuideSection(props: GuideProps) {
+  return (
+    <>
+      <S.guideDiv>
+        <S.guideTitle>
+          {props.title}
+        </S.guideTitle>
+        <S.guideSection>
+          {props.step1}
+        </S.guideSection>
+        <S.guideSection>
+          {props.step2}
+        </S.guideSection>
+        <S.guideSection>
+          {props.step3}
+        </S.guideSection>
+      </S.guideDiv>
+    </>
+  )
+}

--- a/src/Pages/BackgroundPage/BackgroundPage.tsx
+++ b/src/Pages/BackgroundPage/BackgroundPage.tsx
@@ -5,6 +5,8 @@ import { Link } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
 import Button from '../../Common/Button/Button';
 import { backgroundState } from '../recoil';
+import Guide from '../../Common/GuideSection/GuideSection';
+
 import * as S from './BackgroundPage.styled'
 
 
@@ -32,6 +34,8 @@ export default function BackgroundPage() {
       <GlobalStyles />
       <S.backgroundDiv >
         <h1>편지의 배경을 선택하는 페이지 입니다.</h1>
+        <Guide title='편지지의 그라데이션 배경을 설정하는 방법' step1='1. 원하시는 색을 클릭하고 색 더하기를 눌러보세요' step2='2. 색상의 반전을 원하시면 색 반전 버튼을 클릭하시면 됩니다.'
+          step3='* 그라데이션은 두 개의 색을 결합한 디자인을 의미하며 색을 추가하면 기존의 색을 밀어 올리는 방식으로 제작됩니다.' />
         <section style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', marginBottom: 20 }}>
           <HexColorPicker color={color} onChange={setColor} />
         </section>


### PR DESCRIPTION
# 1. 공용 컴퍼넌트에 각 페이지에 대한 가이드라인을 작성할 수 있는 guideSection 컴퍼넌트를 추가했습니다.
- props를 통해 각 페이지에 필요한 guide내용을 작성할 수 있는 guideSection을 추가했습니다.
- props의 경우, 가이드의 제목인 title과 그에 따른 순서를 step1,2,3를 만들었는데, step1의 type은 string으로 표현했으며, 나머지 step2,3의 경우, 내용이 없을 수 도 있기에 type을 string | null로 구현했습니다.
- 현재는 backgruond 페이지만 적용된 상태이며, 추후에 다른 페이지에도 적용할 예정입니다.
- 해당 컴퍼넌트의 제목이 section이지만, div로 구현 되어 있으며, step부분이 section태그인 것이 태그의 용도와 맞지 않기에 추후에 수정할 예정입니다.