### PR TITLE
feat : 각 페이지에 guideSection 추가 및 페이지 별 기능 개선

### DIFF
--- a/src/Common/GuideSection/GuideSection.styled.ts
+++ b/src/Common/GuideSection/GuideSection.styled.ts
@@ -1,14 +1,13 @@
 import { styled } from 'styled-components';
 import { back } from '../../img/img';
 
-export const guideDiv = styled.div`
+export const guideDiv = styled.section`
   max-width: 400px;
   margin: auto;
   margin-top: 20px;
   margin-bottom: 20px;
   display: flex;
   flex-direction: column;
-  gap: 5px;
   border-radius: 10px;
   background-image: url(${back});
   background-repeat: no-repeat;
@@ -16,9 +15,14 @@ export const guideDiv = styled.div`
   background-size: cover;
 `;
 
-export const guideSection = styled.section`
+export const guideSteps = styled.p`
   width: auto;
-  margin-bottom: 10px;
+  margin-bottom: 5px;
+  text-align: start;
+  padding-left: 7px;
+  word-break: break-all;
+  font-size: 16px;
+  font-weight: bold;
 `;
 
 export const guideTitle = styled.h2`

--- a/src/Common/GuideSection/GuideSection.tsx
+++ b/src/Common/GuideSection/GuideSection.tsx
@@ -15,15 +15,15 @@ export default function GuideSection(props: GuideProps) {
         <S.guideTitle>
           {props.title}
         </S.guideTitle>
-        <S.guideSection>
+        <S.guideSteps>
           {props.step1}
-        </S.guideSection>
-        <S.guideSection>
+        </S.guideSteps>
+        <S.guideSteps>
           {props.step2}
-        </S.guideSection>
-        <S.guideSection>
+        </S.guideSteps>
+        <S.guideSteps>
           {props.step3}
-        </S.guideSection>
+        </S.guideSteps>
       </S.guideDiv>
     </>
   )

--- a/src/Pages/ImagePage/ImagePage.tsx
+++ b/src/Pages/ImagePage/ImagePage.tsx
@@ -5,6 +5,7 @@ import { Link } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
 import { imageState } from '../recoil';
 import Button from '../../Common/Button/Button'
+import Guide from '../../Common/GuideSection/GuideSection';
 import 'react-responsive-carousel/lib/styles/carousel.min.css';
 
 
@@ -12,11 +13,16 @@ import 'react-responsive-carousel/lib/styles/carousel.min.css';
 export default function ImagePage() {
   const [imageArray, setImageArray] = useRecoilState<string[]>(imageState);
 
+
   const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
+    const file = e.target.files;
+    let imageUrlList = [...imageArray];
     if (file) {
-      const imageUrl = URL.createObjectURL(file);
-      setImageArray([...imageArray, imageUrl]);
+      for (let i = 0; i < file.length; i++) {
+        const imageUrl = URL.createObjectURL(file[i]);
+        imageUrlList.push(imageUrl)
+      }
+      setImageArray(imageUrlList);
     }
   }
 
@@ -29,7 +35,8 @@ export default function ImagePage() {
   return (
     <S.ImageDiv>
       <h1>여러분들이 함께한 추억을 올리는 단계입니다.</h1>
-      <S.ImageInput type="file" accept='image/*' onChange={handleImageChange} />
+      <Guide title='이미지 업로드하는 방법' step1='- 파일선택 버튼을 클릭하여 원하시는 사진을 업로드 해주세요.' step2={null} step3={null}></Guide>
+      <S.ImageInput type="file" multiple accept='image/*' onChange={handleImageChange} placeholder='사진을 올려주세요.' />
       <S.ImageSection>
         <Carousel showArrows={true} selectedItem={imageArray.length - 1} showStatus={false} >
           {imageArray.map((image, index) => (

--- a/src/Pages/InfoPage/InfoPage.tsx
+++ b/src/Pages/InfoPage/InfoPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
 import { userState, nameState } from '../recoil';
 import Button from '../../Common/Button/Button'
+import Guide from '../../Common/GuideSection/GuideSection';
 import * as S from './InfoPage.styled';
 
 export default function InfoPage() {
@@ -23,18 +24,23 @@ export default function InfoPage() {
   return (
     <S.InfoDiv>
       <h1>편지에 작성할 기본 정보들을 입력하는 단계입니다.</h1>
+      <Guide title='발신자와 수신자 설정 방법' step1='1. 상단에 있는 칸에는 발신자 분의 성함을 입력해주세요.' step2='2. 수신 하단에 있는 칸에는 수신자 분의 성함을 입력해주세요.'
+        step3='*해당 정보는 필수 정보이기에 꼭 입력해주세요!!' ></Guide>
+
       <form>
         <p>당신의 성함은?</p>
         <input
           type="text"
           value={user}
           onChange={(e) => setUser(e.target.value)}
+          placeholder='발신자 성함'
         />
         <p>이 편지를 받고 감동할 분의 성함은?</p>
         <input
           type="text"
           value={name}
           onChange={(e) => setName(e.target.value)}
+          placeholder='수신자 성함'
         />
       </form>
 

--- a/src/Pages/TestPage/TestPage.tsx
+++ b/src/Pages/TestPage/TestPage.tsx
@@ -39,6 +39,7 @@ export default function TestPage() {
     backgroundContain: 'contain',
   };
 
+
   return (
     <S.testBody >
       <S.testDiv>
@@ -60,7 +61,7 @@ export default function TestPage() {
         {image.length > 0 &&
           <S.photoBox style={{ fontFamily: font }}>
             <h2>우리가 함께한 추억 모음집</h2>
-            <Carousel showArrows={true} selectedItem={image.length - 1} showStatus={false} showThumbs={false}>
+            <Carousel showArrows={true} selectedItem={0} showStatus={false} showThumbs={false}>
               {image.map((image, index) => (
                 <div key={index}>
                   <img src={image} style={{ width: 300, margin: 'auto', display: 'block', alignItems: 'center' }} />

--- a/src/Pages/WrittingPage/WrittingPage.tsx
+++ b/src/Pages/WrittingPage/WrittingPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
 import { textState, fontState, sizeState, textBackState } from '../recoil';
 import Button from '../../Common/Button/Button'
+import Guide from '../../Common/GuideSection/GuideSection';
 import * as S from './Wrtiting.styled';
 import { img1, img2, img3, img4, img5 } from '../../img/img';
 
@@ -12,10 +13,23 @@ export default function WrittingPage() {
   const [font, setFont] = useRecoilState<string>(fontState)
   const [size, setSize] = useRecoilState<string>(sizeState)
   const [selectImage, setSelectImage] = useRecoilState<string>(textBackState);
+  const [hide, setHide] = useState('편지 설정 숨기기')
+  const [hideSection, setHideSection] = useState(`block`)
+
   const navigate = useNavigate()
 
   const handleFontChange = (e: React.ChangeEvent<HTMLSelectElement>) => { setFont(e.target.value) }
   const handleSizeChange = (e: React.ChangeEvent<HTMLSelectElement>) => { setSize(e.target.value) }
+  const handleSettingHide = () => {
+    if (hide === '편지 설정 숨기기') {
+      setHide('편지 설정 보이기')
+      setHideSection(`none`)
+    } else {
+      setHide('편지 설정 숨기기')
+      setHideSection(`block`)
+    }
+
+  }
 
   const handleImageChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     setSelectImage(e.target.value);
@@ -29,13 +43,16 @@ export default function WrittingPage() {
     }
   }
 
-
   const writingAreaStyle = {
     fontSize: `${size}px`,
     fontFamily: font,
     backgroundImage: `url(${selectImage})`,
     backgroundRepeat: 'no-repeat',
   };
+
+  const hideSectionStyle = {
+    display: `${hideSection}`
+  }
 
   return (
     <S.WritingDiv>
@@ -44,40 +61,45 @@ export default function WrittingPage() {
         rel="stylesheet"
       />
       <h1>편지에 작성할 편지내용을 입력하는 단계입니다.</h1>
-      <p>원하시는 글자 폰트를 선택해주세요</p>
-      <label htmlFor="">
-        <select id="fontSelector" value={font} onChange={handleFontChange}>
-          <option value="Roboto">Roboto</option>
-          <option value="Black Han Sans">Black Han Sans</option>
-          <option value="Nanum Pen Script">Nanum Pen Script</option>
-          <option value="Nanum Myeongjo">Nanum Myeongjo</option>
-          <option value="Bagel Fat One">Bagel Fat One</option>
-        </select>
-      </label>
-      <p>원하시는 글자 크기를 선택해주세요</p>
-      <label htmlFor="">
-        <select id="sizeSelector" value={size} onChange={handleSizeChange}>
-          <option value="7">7px</option>
-          <option value="8">8px</option>
-          <option value="10">10px</option>
-          <option value="12">12px</option>
-          <option value="14">14px</option>
-          <option value="24">24px</option>
-          <option value="32">32px</option>
-          <option value="48">48px</option>
-        </select>
-      </label>
-      <p>원하시는 편지지를 선택해주세요</p>
-      <label htmlFor="">
-        <select id="backgroundSelector" value={selectImage} onChange={handleImageChange}>
-          <option value=''>none</option>
-          <option value={img1}>스타일1</option>
-          <option value={img2}>스타일2</option>
-          <option value={img3}>스타일3</option>
-          <option value={img4}>스타일4</option>
-          <option value={img5}>스타일5</option>
-        </select>
-      </label>
+      <Guide title='편지 작성 가이드' step1='1. 원하시는 글자의 폰트와 크기, 편지지의 배경을 선택해주세요.' step2='2. 폰트 설정 숨기기 버튼을 누르시고 하단의 편지지에 편지를 작성하시면 됩니다.' step3='*글자 수에는 제한은 없지만, 글자 크기는 되도록 24px로 하시는 것을 권장드립니다.'></Guide>
+      <button onClick={handleSettingHide}>{hide}</button>
+      <S.hideSection style={hideSectionStyle}>
+        <p>원하시는 글자 폰트를 선택해주세요</p>
+        <label htmlFor="">
+          <select id="fontSelector" value={font} onChange={handleFontChange}>
+            <option value="Roboto">Roboto</option>
+            <option value="Black Han Sans">Black Han Sans</option>
+            <option value="Nanum Pen Script">Nanum Pen Script</option>
+            <option value="Nanum Myeongjo">Nanum Myeongjo</option>
+            <option value="Bagel Fat One">Bagel Fat One</option>
+          </select>
+        </label>
+        <p>원하시는 글자 크기를 선택해주세요</p>
+        <label htmlFor="">
+          <select id="sizeSelector" value={size} onChange={handleSizeChange}>
+            <option value="7">7px</option>
+            <option value="8">8px</option>
+            <option value="10">10px</option>
+            <option value="12">12px</option>
+            <option value="14">14px</option>
+            <option value="24">24px</option>
+            <option value="32">32px</option>
+            <option value="48">48px</option>
+          </select>
+        </label>
+        <p>원하시는 편지지를 선택해주세요</p>
+        <label htmlFor="">
+          <select id="backgroundSelector" value={selectImage} onChange={handleImageChange}>
+            <option value=''>none</option>
+            <option value={img1}>스타일1</option>
+            <option value={img2}>스타일2</option>
+            <option value={img3}>스타일3</option>
+            <option value={img4}>스타일4</option>
+            <option value={img5}>스타일5</option>
+          </select>
+        </label>
+      </S.hideSection>
+
 
       <S.WritingForm>
         <S.WritingArea name="letter" cols={100} rows={30} style={writingAreaStyle} value={text} onChange={e => setText(e.target.value)} placeholder='여러분이 전하고 싶은 마음의 소리를 적어보세요'></S.WritingArea>

--- a/src/Pages/WrittingPage/Wrtiting.styled.ts
+++ b/src/Pages/WrittingPage/Wrtiting.styled.ts
@@ -6,6 +6,10 @@ export const WritingDiv = styled.div`
   text-align: center;
 `;
 
+export const hideSection = styled.section`
+  display: block;
+`;
+
 export const WritingForm = styled.form`
   width: 400px;
   margin: auto;


### PR DESCRIPTION
# 1. 편지 작성에 필요한 모든 페이지에 공용 컴퍼넌트인 guideSection을 추가했습니다.
- 사용자의 편지 작성 편의성을 높이기 위해서 공용 컴퍼넌트로 작성된 guideSection을 추가했습니다.
- 용어나 폰트 등 기타 UI는 추후에 개선할 예정입니다.

# 2. 편지 작성에 방해가 될 수 있는 편지 설정 section을 숨길 수 있는 버튼을 추가했습니다.
- 모바일 사용자의 경우, 편지 설정 section때문에 편지 작성에 불편이 있다고 판단했습니다.
- 이를 개선하고자, 버튼을 통한 on/off 기능을 추가하여 해결했습니다.

# 3. 여러 이미지를 한 번에 업로드 할 수 있는 기능을 추가했습니다.
- 이미지를 하나씩 올리는 것이 불편하기에, 다중 이미지 업로드를 할 수 있도록 기능을 개선했습니다.

# 4. 테스트 페이지에 이미지가 렌더링 되었을때, 업로드 된 순서부터 볼 수 있도록 설정했습니다.
- 기존에는 가장 마지막에 업로드 된 이미지부터 렌더링 되어 carousel을 거꾸로 거슬러 올라가야하는 불편사항이 있었습니다.
- 렌더링이 되자마자 맨 앞부터 렌더링 되게 구현 함으로써 해당 문제를 해결했습니다.