### PR TITLE
feat: 편지 배경의 태그 위치 변경

### DIFF
--- a/src/Pages/WrittingPage/WrittingPage.tsx
+++ b/src/Pages/WrittingPage/WrittingPage.tsx
@@ -46,9 +46,12 @@ export default function WrittingPage() {
   const writingAreaStyle = {
     fontSize: `${size}px`,
     fontFamily: font,
+  };
+
+  const writingFormStyle = {
     backgroundImage: `url(${selectImage})`,
     backgroundRepeat: 'no-repeat',
-  };
+  }
 
   const hideSectionStyle = {
     display: `${hideSection}`
@@ -101,7 +104,7 @@ export default function WrittingPage() {
       </S.hideSection>
 
 
-      <S.WritingForm>
+      <S.WritingForm style={writingFormStyle}>
         <S.WritingArea name="letter" cols={100} rows={30} style={writingAreaStyle} value={text} onChange={e => setText(e.target.value)} placeholder='여러분이 전하고 싶은 마음의 소리를 적어보세요'></S.WritingArea>
       </S.WritingForm>
 

--- a/src/Pages/WrittingPage/Wrtiting.styled.ts
+++ b/src/Pages/WrittingPage/Wrtiting.styled.ts
@@ -13,7 +13,10 @@ export const hideSection = styled.section`
 export const WritingForm = styled.form`
   width: 400px;
   margin: auto;
-  margin-top: 20px;
+  height: 400px;
+  background-size: cover;
+  background-position: center;
+  border-radius: 10px;
 
   @media (max-width: 500px) {
     max-width: 100%;
@@ -25,15 +28,16 @@ export const WritingArea = styled.textarea`
     outline: none;
   }
   display: block;
-  width: 100%;
-  height: 400px;
+  max-width: 100%;
+  height: 380px;
   resize: none;
+  margin-top: 20px;
   margin-bottom: 20px;
   border-radius: 10px;
-  background-size: contain;
+  background: none;
+  border: 0;
 
   @media (max-width: 500px) {
-    max-height: 400px;
-    padding: 0;
+    width: 100%;
   }
 `;


### PR DESCRIPTION
# 1. 기존에 textarea 태그의 배경이 변경되는 것을 form태그의 배경이 변경되도록 수정했습니다.
- 편지를 작성할 때, 텍스트 시작이 맨 왼쪽으로 붙어있는 것이 편지 작성이나 미관상 좋지 않다고 판단하여 padding값을 줬으나, 선택한 배경이미지가 같이 이동하는 오류가 있었습니다.
- 이를 해결하고자, 기존의 textarea에 있던 배경 변경 기능을 form태그에서 이루어 지도록 설정했습니다.
- 텍스트의 시작위치에 padding값을 부여하는 것은 추후에 적용할 예정입니다.