### PR TITLE
feat: 공용 컴퍼넌트에 헤더와 풋터 컴퍼넌트 추가 및 편지 작성 텍스트 시작 위치 변경

### DIFF
--- a/src/Common/Footer/Footer.styled.ts
+++ b/src/Common/Footer/Footer.styled.ts
@@ -1,0 +1,1 @@
+import styled from 'styled-components';

--- a/src/Common/Footer/Footer.tsx
+++ b/src/Common/Footer/Footer.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import * as S from './Footer.styled'
+
+export default function Footer() {
+  return (
+    <>
+      <footer>
+        <div>풋터입니다.</div>
+      </footer>
+    </>
+  )
+}

--- a/src/Common/Header/Header.styled.ts
+++ b/src/Common/Header/Header.styled.ts
@@ -1,0 +1,1 @@
+import styled from 'styled-components';

--- a/src/Common/Header/Header.tsx
+++ b/src/Common/Header/Header.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import * as S from './Header.styled'
+
+export default function Header() {
+  return (
+    <>
+      <header>
+        <div>헤더입니다.</div>
+      </header>
+    </>
+  )
+}

--- a/src/Pages/FirstPage/FirstPage.tsx
+++ b/src/Pages/FirstPage/FirstPage.tsx
@@ -1,15 +1,19 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import * as S from './FirstPage.styled';
+import Header from '../../Common/Header/Header';
+import Footer from '../../Common/Footer/Footer';
 
 export default function FirstPage() {
   return (
     <S.mainDiv>
+      <Header />
       <h1>스타트 페이지</h1>
       <p>감사한 분에게 여러분만의 편지를 만들어 마음을 전달해봐요</p>
       <Link to="/background">
         <button>편지 작성하러 이동</button>
       </Link>
+      <Footer />
     </S.mainDiv>
   );
 }

--- a/src/Pages/WrittingPage/Wrtiting.styled.ts
+++ b/src/Pages/WrittingPage/Wrtiting.styled.ts
@@ -30,9 +30,10 @@ export const WritingArea = styled.textarea`
   display: block;
   max-width: 100%;
   height: 380px;
-  resize: none;
   margin-top: 20px;
-  margin-bottom: 20px;
+  resize: none;
+  box-sizing: border-box;
+  padding: 10px;
   border-radius: 10px;
   background: none;
   border: 0;


### PR DESCRIPTION
# 1. 공용 컴퍼넌트에 헤더와 풋터 컴퍼넌트를 추가했습니다.
- 보다 프로젝트의 완성도를 높이고, 기존 페이지 이동 버튼 기능을 대신할 헤더와 프로젝트의 저작권을 표시할 풋터를 추가할 계획입니다.
- 현재는 폴더와 파일만 생성된 상태이며, 추후에 작업 예정입니다.

# 2. 편지 작성 텍스트 시작 위치를 편지지의 안쪽에서 작성할 수 있도록 변경했습니다.
- 기존의 텍스트 시작 커서가 편지지의 가장 왼쪽 맨 위에 붙어 사용자로 하여금 작성 및 미관상의 불편을 야기한다고 판단했습니다.
- 이를 개선하고자 box-sizing: border-box;로 수정하여 padding값을 줘 시작 커서 위치를 편지지 안쪽으로 변경했습니다.
