### PR TITLE
feat: Open Graph image 작업 최종 수정

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,10 +24,10 @@
     <meta property="og:url" content="https://seunggyu-jung.github.io/" />
     <meta
       property="og:image"
-      content="https://velog.velcdn.com/images/dainel-q/post/f9ed965f-14e3-4db6-94e4-a35269e74528/image.png"
+      content="https://velog.velcdn.com/images/dainel-q/post/41c3a16f-efc5-45c5-99fd-73274d825bce/image.png"
     />
-    <!-- <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="630" /> -->
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
 
     <title>감동 프로젝트</title>
   </head>


### PR DESCRIPTION
# 1.  Open Graph image 작업 최종 수정
- 그동안 pc 카카오톡에서 Open Graph image가 출력되지 않아 고민했으나, 모바일로 출력이 잘되고 있었습니다.
- 따라서 모바일과 웹 환경을 동시에 고려해야하기 때문에 600*315 사이즈의 이미지를 채택했습니다.