### PR TITLE
feat: footer 항시 하단 고정 기능 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,7 +41,7 @@ function App() {
   `
 
   return (
-    <div>
+    <>
       <GlobalStyles />
       <HashRouter>
         <ScrollToTop />
@@ -56,7 +56,7 @@ function App() {
           <Route path="/bgm" element={<BgmPage />}></Route>
         </Routes>
       </HashRouter>
-    </div>
+    </>
   );
 }
 

--- a/src/Common/Footer/Footer.styled.ts
+++ b/src/Common/Footer/Footer.styled.ts
@@ -1,1 +1,8 @@
 import styled from 'styled-components';
+
+export const footer = styled.footer`
+  border: 1px solid black;
+  height: 100px;
+  position: relative;
+  transform: translateY(-100%);
+`;

--- a/src/Common/Footer/Footer.tsx
+++ b/src/Common/Footer/Footer.tsx
@@ -4,9 +4,7 @@ import * as S from './Footer.styled'
 export default function Footer() {
   return (
     <>
-      <footer>
-        <div>풋터입니다.</div>
-      </footer>
+      <S.footer></S.footer>
     </>
   )
 }


### PR DESCRIPTION
# 1. 컨텐츠 양에 관계없이 footer가 항시 하단에 고정하도록 설정했습니다.
- 기존에는 컨텐츠의 양이 적으면 컨텐츠 바로 밑에 생겨 웹페이지의 가시성이나 footer로서의 기능을 제대로 하지 못했습니다.
- 이를 해결하기 위해, 페이지의 wrapper에 min-height값을 주고, padding-bottom을 주고, footer를  position: relative 와 transform: translateY(-100%)로 작성하여 해당문제를 해결했습니다.
