### PR TITLE
feat: header 공용 컴퍼넌트 추가

### DIFF
--- a/src/Common/Header/Header.styled.ts
+++ b/src/Common/Header/Header.styled.ts
@@ -1,1 +1,58 @@
 import styled from 'styled-components';
+import { Link } from 'react-router-dom';
+
+export const headerWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  height: 80px;
+`;
+
+export const header = styled.header`
+  border-bottom: 1px solid black;
+  width: calc(100% - 200px);
+  height: 80px;
+  display: flex;
+  justify-content: space-between;
+  position: fixed;
+  padding: 10px 0;
+
+  @media (max-width: 500px) {
+    width: 100%;
+  }
+`;
+
+export const menuContainer = styled.section`
+  height: 80px;
+  display: flex;
+  @media (max-width: 500px) {
+    width: 80px;
+    flex-direction: column;
+  }
+`;
+
+export const menuButton = styled.button`
+  width: 80px;
+  height: 80px;
+  position: absolute;
+  right: 0;
+`;
+
+export const headerUl = styled.ul`
+  display: flex;
+  flex-direction: column;
+  list-style: none;
+  background-color: #ffff;
+  & {
+    padding: 0;
+    position: absolute;
+    top: 75px;
+    right: 10px;
+    transition: 0.5s es;
+  }
+  gap: 30px;
+`;
+
+export const headerLink = styled(Link)`
+  text-decoration: none;
+  color: black;
+`;

--- a/src/Common/Header/Header.tsx
+++ b/src/Common/Header/Header.tsx
@@ -1,12 +1,48 @@
-import React from 'react'
+import React, { useState } from 'react'
 import * as S from './Header.styled'
+import { guide2 } from '../../img/img'
+import { Link } from 'react-router-dom'
+
 
 export default function Header() {
+
+  const [menuText, setMenuText] = useState("메뉴 펼치기")
+  const [clickMenu, setClickMenu] = useState(false);
+
+  const handleMenu = () => {
+    if (clickMenu === false) {
+      setClickMenu(true)
+      setMenuText("메뉴 접기")
+    } else {
+      setClickMenu(false)
+      setMenuText("메뉴 펼치기")
+    }
+  }
+
   return (
     <>
-      <header>
-        <div>헤더입니다.</div>
-      </header>
+      <S.headerWrapper>
+        <S.header>
+          <img src={guide2} alt="" />
+          <h1>감동 프로젝트</h1>
+          <div>
+            <S.menuContainer>
+              <S.menuButton onClick={handleMenu}>{menuText}</S.menuButton>
+              {clickMenu &&
+                <S.headerUl>
+                  <li> <S.headerLink to="/" >처음</S.headerLink></li>
+                  <li><S.headerLink to="/background">배경</S.headerLink></li>
+                  <li><S.headerLink to="/info">정보</S.headerLink></li>
+                  <li><S.headerLink to="/write">편지작성</S.headerLink></li>
+                  <li><S.headerLink to="/image">사진</S.headerLink></li>
+                  <li><S.headerLink to="/bgm">배경음악</S.headerLink></li>
+                </S.headerUl>
+              }
+            </S.menuContainer>
+          </div>
+
+        </S.header>
+      </S.headerWrapper>
     </>
   )
 }


### PR DESCRIPTION
# 1. header 공용 컴퍼넌트를 추가했습니다.
- 보다 틀이 갖추어진 페이지를 만들고, 기존의 리모컨 방식의 페이지 이동에 제약이 많다고 판단되어 페이지 이동 기능이 있는 header를 추가했습니다.
- header의 우측 '메뉴 펼치기'를 누르면 ul,li태그로 작성된 리모컨이 나와 원하는 페이지로 이동할 수 있습니다.
- 메뉴버튼의 UI나 기능적인 개선은 추후에 작업할 예정입니다.