### PR TITLE
feat: header page_remote_controller 기능 추가

### DIFF
--- a/src/Common/Header/Header.styled.ts
+++ b/src/Common/Header/Header.styled.ts
@@ -4,17 +4,21 @@ import { Link } from 'react-router-dom';
 export const headerWrapper = styled.div`
   display: flex;
   justify-content: center;
+  width: 100%;
   height: 80px;
+  margin: auto;
+  background-color: #ffff;
 `;
 
 export const header = styled.header`
-  border-bottom: 1px solid black;
-  width: calc(100% - 200px);
+  background-color: #ffff;
+  width: calc(100% - 600px);
   height: 80px;
   display: flex;
   justify-content: space-between;
+  text-align: center;
   position: fixed;
-  padding: 10px 0;
+  z-index: 1;
 
   @media (max-width: 500px) {
     width: 100%;
@@ -35,19 +39,114 @@ export const menuButton = styled.button`
   height: 80px;
   position: absolute;
   right: 0;
+  background-color: salmon;
+  border: 0;
+  border-radius: 10px 10px 10px 10px;
+  z-index: 1;
+
+  .menu-trigger {
+  }
+  .menu-trigger,
+  .menu-trigger span {
+    display: inline-block;
+    transition: all 0.4s;
+    box-sizing: border-box;
+  }
+
+  .menu-trigger {
+    position: relative;
+    width: 50px;
+    height: 44px;
+  }
+
+  .menu-trigger span {
+    position: absolute;
+    left: 0;
+    width: 100%;
+    height: 4px;
+    background-color: #fff;
+    border-radius: 4px;
+  }
+
+  .menu-trigger span:nth-of-type(1) {
+    top: 0;
+  }
+
+  .menu-trigger span:nth-of-type(2) {
+    top: 20px;
+  }
+
+  .menu-trigger span:nth-of-type(3) {
+    bottom: 0;
+  }
+
+  /* type-01 */
+  /* 중앙 라인이 고정된 자리에서 투명하게 사라지며 상하라인 회전하며 엑스자 만들기 */
+  .menu-trigger.active-1 span:nth-of-type(1) {
+    -webkit-transform: translateY(20px) rotate (-45deg);
+    transform: translateY(20px) rotate(-45deg);
+  }
+
+  .menu-trigger.active-1 span:nth-of-type(2) {
+    opacity: 0;
+  }
+
+  .menu-trigger.active-1 span:nth-of-type(3) {
+    -webkit-transform: translateY(-20px) rotate(45deg);
+    transform: translateY(-20px) rotate(45deg);
+  }
 `;
 
-export const headerUl = styled.ul`
+export const headerUl = styled.ul<{ menuVisible: boolean }>`
   display: flex;
   flex-direction: column;
   list-style: none;
   background-color: #ffff;
+  border-radius: 0 0 10px 10px;
+
+  @keyframes dropdown {
+    0% {
+      transform: translateY(-100%);
+    }
+    100% {
+      transform: translateY(0);
+    }
+  }
+
+  @keyframes scrollup {
+    0% {
+      transform: translateY(0);
+    }
+    100% {
+      transform: translateY(-100%);
+    }
+  }
+
+  animation: ${(props) =>
+    props.menuVisible
+      ? 'dropdown 0.4s ease forwards'
+      : 'scrollup 0.4s ease-in forwards'};
+
   & {
     padding: 0;
     position: absolute;
-    top: 75px;
-    right: 10px;
-    transition: 0.5s es;
+    top: 65px;
+    right: 0;
+    width: 80px;
+
+    ::after {
+      content: '';
+      display: block;
+      width: 0;
+      height: 2px;
+      background-color: salmon;
+      transition: width 0.2s ease-out;
+    }
+
+    :hover::after {
+      width: 100%;
+      transition: width 0.2s ease;
+    }
   }
   gap: 30px;
 `;

--- a/src/Common/Header/Header.tsx
+++ b/src/Common/Header/Header.tsx
@@ -8,6 +8,7 @@ export default function Header() {
 
   const [menuText, setMenuText] = useState("메뉴 펼치기")
   const [clickMenu, setClickMenu] = useState(false);
+  const [menuDefault, setMenuDefault] = useState(false);
 
   const handleMenu = () => {
     if (clickMenu === false) {
@@ -17,7 +18,9 @@ export default function Header() {
       setClickMenu(false)
       setMenuText("메뉴 펼치기")
     }
+    setMenuDefault(true);
   }
+
 
   return (
     <>
@@ -27,9 +30,13 @@ export default function Header() {
           <h1>감동 프로젝트</h1>
           <div>
             <S.menuContainer>
-              <S.menuButton onClick={handleMenu}>{menuText}</S.menuButton>
-              {clickMenu &&
-                <S.headerUl>
+              <S.menuButton onClick={handleMenu}><a className="menu-trigger" href="#">
+                <span></span>
+                <span></span>
+                <span></span>
+              </a></S.menuButton>
+              {menuDefault &&
+                <S.headerUl menuVisible={clickMenu}>
                   <li> <S.headerLink to="/" >처음</S.headerLink></li>
                   <li><S.headerLink to="/background">배경</S.headerLink></li>
                   <li><S.headerLink to="/info">정보</S.headerLink></li>


### PR DESCRIPTION
# 1. header에 페이지를 이동할 수 있는 page_remote_controller를 추가했습니다.
- header의 햄버거 버튼을 클릭하면 원하는 페이지로 이동할 수 있는 기능을 추가했습니다.
- 추후에, 해당 조건이 만족하지 않으면 해당 페이지로 넘어갈 수 없게 제한 하는 기능을 추가할 예정입니다.
- 햄버거 버튼을 클릭하면 페이지 이동 메뉴가 자연스럽게 내려왔다가 다시 올라가는 기능을 구현했습니다.(@keyframe 사용)
- 원하는 페이지를 hover했을때, 하단에 밑줄이 자연스럽게 생겼다가 hover를 제거하면 자연스럽게 제거되는 효과를 추가했습니다.
- 햄버거 버튼의 동적 효과는 추후에 작업할 예정입니다.