### PR TITLE
feat: BackgroundPage에 header와 footer 추가 및 infopage의 alert경고문을 Modal로 변경

### DIFF
--- a/src/Common/Modal/ModalBox.styled.ts
+++ b/src/Common/Modal/ModalBox.styled.ts
@@ -1,0 +1,27 @@
+import { styled } from 'styled-components';
+
+export const modalContainer = styled.div`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background-color: #fff;
+  border-radius: 10px;
+  padding: 40px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+`;
+
+export const modalAnchor = styled.button`
+  width: 100%;
+  padding: 20px;
+  background: none;
+  border-radius: 10px;
+  border: 1px solid black;
+
+  &:hover {
+    background-color: antiquewhite;
+  }
+`;

--- a/src/Pages/BackgroundPage/BackgroundPage.styled.ts
+++ b/src/Pages/BackgroundPage/BackgroundPage.styled.ts
@@ -2,6 +2,9 @@ import styled from 'styled-components';
 
 export const backgroundDiv = styled.div`
   max-width: 800px;
+  height: auto;
+  min-height: calc(100% - 200px);
+  padding-bottom: 200px;
   margin: auto;
   margin-top: 80px;
   text-align: center;

--- a/src/Pages/BackgroundPage/BackgroundPage.tsx
+++ b/src/Pages/BackgroundPage/BackgroundPage.tsx
@@ -6,6 +6,8 @@ import { useRecoilState } from 'recoil';
 import Button from '../../Common/Button/Button';
 import { backgroundState } from '../recoil';
 import Guide from '../../Common/GuideSection/GuideSection';
+import Header from '../../Common/Header/Header';
+import Footer from '../../Common/Footer/Footer';
 
 import * as S from './BackgroundPage.styled'
 
@@ -30,8 +32,9 @@ export default function BackgroundPage() {
   }
 
   return (
-    <div>
+    <>
       <GlobalStyles />
+      <Header />
       <S.backgroundDiv >
         <h1>편지의 배경을 선택하는 페이지 입니다.</h1>
         <Guide title='편지지의 그라데이션 배경을 설정하는 방법' step1='1. 원하시는 색을 클릭하고 색 더하기를 눌러보세요' step2='2. 색상의 반전을 원하시면 색 반전 버튼을 클릭하시면 됩니다.'
@@ -45,6 +48,7 @@ export default function BackgroundPage() {
         <Button previousLink='/' nextLink='/info' />
 
       </S.backgroundDiv>
-    </div>
+      <Footer />
+    </>
   )
 }

--- a/src/Pages/InfoPage/InfoPage.tsx
+++ b/src/Pages/InfoPage/InfoPage.tsx
@@ -1,50 +1,72 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
 import { userState, nameState } from '../recoil';
 import Button from '../../Common/Button/Button'
 import Guide from '../../Common/GuideSection/GuideSection';
+import Modal from '../../Common/Modal/Modal';
 import * as S from './InfoPage.styled';
+import * as M from '../../Common/Modal/ModalBox.styled';
 
 export default function InfoPage() {
   const [user, setUser] = useRecoilState(userState);
   const [name, setName] = useRecoilState(nameState);
-  const navigate = useNavigate()
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [warningMsg, setWarningMsg] = useState("");
+
+  const closeModal = () => setIsModalOpen(false);
+
+  const navigate = useNavigate();
+
 
   const handleEmty = () => {
     if (user.toString().trim().length === 0) {
-      alert("당신의 성함을 입력해주세요!")
+      setWarningMsg("당신의 성함을 입력해주세요!");
+      setIsModalOpen(true);
     } else if (name.toString().trim().length === 0) {
-      alert("편지를 받을 분의 성함을 입력해주세요!")
+      setWarningMsg("편지를 받을 분의 성함을 입력해주세요!");
+      setIsModalOpen(true);
     } else {
       navigate('/write')
     }
   }
 
   return (
-    <S.InfoDiv>
-      <h1>편지에 작성할 기본 정보들을 입력하는 단계입니다.</h1>
-      <Guide title='발신자와 수신자 설정 방법' step1='1. 상단에 있는 칸에는 발신자 분의 성함을 입력해주세요.' step2='2. 수신 하단에 있는 칸에는 수신자 분의 성함을 입력해주세요.'
-        step3='*해당 정보는 필수 정보이기에 꼭 입력해주세요!!' ></Guide>
+    <>
+      <S.InfoDiv>
+        <h1>편지에 작성할 기본 정보들을 입력하는 단계입니다.</h1>
+        <Guide title='발신자와 수신자 설정 방법' step1='1. 상단에 있는 칸에는 발신자 분의 성함을 입력해주세요.' step2='2. 수신 하단에 있는 칸에는 수신자 분의 성함을 입력해주세요.'
+          step3='*해당 정보는 필수 정보이기에 꼭 입력해주세요!!' ></Guide>
 
-      <form>
-        <p>당신의 성함은?</p>
-        <input
-          type="text"
-          value={user}
-          onChange={(e) => setUser(e.target.value)}
-          placeholder='발신자 성함'
-        />
-        <p>이 편지를 받고 감동할 분의 성함은?</p>
-        <input
-          type="text"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          placeholder='수신자 성함'
-        />
-      </form>
+        <form>
+          <p>당신의 성함은?</p>
+          <input
+            type="text"
+            value={user}
+            onChange={(e) => setUser(e.target.value)}
+            placeholder='발신자 성함'
+          />
+          <p>이 편지를 받고 감동할 분의 성함은?</p>
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder='수신자 성함'
+          />
+        </form>
 
-      <Button previousLink='/background' nextLink={handleEmty} />
-    </S.InfoDiv>
+        <Button previousLink='/background' nextLink={handleEmty} />
+      </S.InfoDiv>
+      {isModalOpen &&
+        <Modal closeModal={closeModal}>
+          <M.modalContainer>
+            <h2>잠깐!</h2>
+            <p>{warningMsg}</p>
+            <p>닫기 : 빈 화면 클릭 or ESC</p>
+          </M.modalContainer>
+        </Modal>
+      }
+    </>
+
   );
 }


### PR DESCRIPTION
# 1.  BackgroundPage에 header와 footer를 추가했습니다.
- 특이사항이 없는 page이기에 header와 footer에 별다른 변화없이 추가했습니다.

# 2. Infopage의 alert경고문을 Modal로 변경
- 기존에 만들어 놓은 모달 창 컴퍼넌트를 활용하여 alert 창보다 더 다양한 기능을 수행할 수 있는 경고문구를 만들었습니다.
- 공용 컴퍼넌트에 Modal창 안에 들어가는 ModalContainer라는 div의 스타일을 관리하는 컴퍼넌트를 생성하여,  모달창을 사용하는 다른 컴퍼넌트에 추가적인 css 작업이 안들어가도 괜찮도록 작업했습니다.

# 3. 기타 사항
- 커스터마이징의 마지막 페이지인 bgm페이지에서 전반적인 검토를 시켜주도록 하면 될 것 같아, header의 링크에 별다른 잠금 기능을 추가하지 않았습니다.