### PR TITLE
feat: header background-color변경 및 header title의 props 전달추가

### DIFF
--- a/src/Common/Header/Header.styled.ts
+++ b/src/Common/Header/Header.styled.ts
@@ -7,11 +7,11 @@ export const headerWrapper = styled.div`
   width: 100%;
   height: 80px;
   margin: auto;
-  background-color: #ffff;
+  background-color: none;
 `;
 
 export const header = styled.header`
-  background-color: #ffff;
+  background-color: none;
   width: calc(100% - 600px);
   height: 80px;
   display: flex;
@@ -23,6 +23,11 @@ export const header = styled.header`
     width: 100%;
     position: fixed;
     z-index: 1;
+    background-color: #fff;
+
+    h1 {
+      font-size: 24px;
+    }
   }
 `;
 
@@ -105,7 +110,6 @@ export const headerUl = styled.ul<{ menuVisible: boolean }>`
   display: flex;
   flex-direction: column;
   list-style: none;
-  background-color: #ffff;
   border-radius: 0 0 10px 10px;
   z-index: 1;
 
@@ -115,6 +119,7 @@ export const headerUl = styled.ul<{ menuVisible: boolean }>`
     }
     100% {
       transform: translateY(0);
+      background-color: #ffff;
     }
   }
 
@@ -124,6 +129,7 @@ export const headerUl = styled.ul<{ menuVisible: boolean }>`
     }
     100% {
       transform: translateY(-100%);
+      background-color: none;
     }
   }
 

--- a/src/Common/Header/Header.tsx
+++ b/src/Common/Header/Header.tsx
@@ -1,53 +1,68 @@
-import React, { useState } from 'react'
-import * as S from './Header.styled'
-import { guide2 } from '../../img/img'
+import React, { useState } from 'react';
+import * as S from './Header.styled';
+import { guide2 } from '../../img/img';
 
+interface HeaderProps {
+  title: string;
+}
 
-export default function Header() {
-
-  const [menuText, setMenuText] = useState("메뉴 펼치기")
+const Header: React.FC<HeaderProps> = ({ title }) => {
+  const [menuText, setMenuText] = useState("메뉴 펼치기");
   const [clickMenu, setClickMenu] = useState(false);
   const [menuDefault, setMenuDefault] = useState(false);
 
   const handleMenu = () => {
     if (clickMenu === false) {
-      setClickMenu(true)
-      setMenuText("메뉴 접기")
+      setClickMenu(true);
+      setMenuText("메뉴 접기");
     } else {
-      setClickMenu(false)
-      setMenuText("메뉴 펼치기")
+      setClickMenu(false);
+      setMenuText("메뉴 펼치기");
     }
     setMenuDefault(true);
-  }
-
+  };
 
   return (
     <>
       <S.headerWrapper>
         <S.header>
           <img src={guide2} alt="" />
-          <h1>감동 프로젝트</h1>
+          <h1>{title}</h1>
           <S.menuContainer>
-            <S.menuButton onClick={handleMenu}><div className="menu-trigger">
-              <span></span>
-              <span></span>
-              <span></span>
-            </div></S.menuButton>
-            {menuDefault &&
+            <S.menuButton onClick={handleMenu}>
+              <div className="menu-trigger">
+                <span></span>
+                <span></span>
+                <span></span>
+              </div>
+            </S.menuButton>
+            {menuDefault && (
               <S.headerUl menuVisible={clickMenu}>
-                <li> <S.headerLink to="/" >처음</S.headerLink></li>
-                <li><S.headerLink to="/background">배경</S.headerLink></li>
-                <li><S.headerLink to="/info">정보</S.headerLink></li>
-                <li><S.headerLink to="/write">편지작성</S.headerLink></li>
-                <li><S.headerLink to="/image">사진</S.headerLink></li>
-                <li><S.headerLink to="/bgm">배경음악</S.headerLink></li>
+                <li>
+                  <S.headerLink to="/">처음</S.headerLink>
+                </li>
+                <li>
+                  <S.headerLink to="/background">배경</S.headerLink>
+                </li>
+                <li>
+                  <S.headerLink to="/info">정보</S.headerLink>
+                </li>
+                <li>
+                  <S.headerLink to="/write">편지작성</S.headerLink>
+                </li>
+                <li>
+                  <S.headerLink to="/image">사진</S.headerLink>
+                </li>
+                <li>
+                  <S.headerLink to="/bgm">배경음악</S.headerLink>
+                </li>
               </S.headerUl>
-            }
+            )}
           </S.menuContainer>
-
-
         </S.header>
       </S.headerWrapper>
     </>
-  )
-}
+  );
+};
+
+export default Header;

--- a/src/Pages/BackgroundPage/BackgroundPage.tsx
+++ b/src/Pages/BackgroundPage/BackgroundPage.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react'
 import { HexColorPicker } from 'react-colorful'
 import { createGlobalStyle } from 'styled-components'
-import { Link } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
 import Button from '../../Common/Button/Button';
 import { backgroundState } from '../recoil';
@@ -34,7 +33,7 @@ export default function BackgroundPage() {
   return (
     <>
       <GlobalStyles />
-      <Header />
+      <Header title='Background Page' />
       <S.backgroundDiv >
         <h1>편지의 배경을 선택하는 페이지 입니다.</h1>
         <Guide title='편지지의 그라데이션 배경을 설정하는 방법' step1='1. 원하시는 색을 클릭하고 색 더하기를 눌러보세요' step2='2. 색상의 반전을 원하시면 색 반전 버튼을 클릭하시면 됩니다.'

--- a/src/Pages/FirstPage/FirstPage.tsx
+++ b/src/Pages/FirstPage/FirstPage.tsx
@@ -28,7 +28,7 @@ export default function FirstPage() {
   return (
     <>
       <S.mainDiv>
-        <Header />
+        <Header title='감동 프로젝트' />
         <S.mainSection>
           <Carousel showArrows={false} showStatus={false} autoPlay={true} infiniteLoop={true} interval={3000} showThumbs={false} showIndicators={false} stopOnHover={false} selectedItem={currentIndex}  >
             {imageArray.map((image, index) => (
@@ -52,6 +52,7 @@ export default function FirstPage() {
             <S.buttonImage src={heart} ></S.buttonImage>
           </S.mainButton>
         </Link>
+        <p>클릭해서 편지를 작성해봐요!</p>
       </S.mainDiv>
       <Footer />
     </>


### PR DESCRIPTION
# 1. pc 웹 header의 배경색을 투명하게 변경했습니다.
- pc 웹의 경우, header가 fixed되어 있지 않아 흰 배경색의 header가 미관을 흐린다고 판단하여 배경색을 투명하게 변경했습니다.
- 모바일 웹의 경우, 기존과 동일하게 header에 배경이 흰색으로 들어가있습니다.

# 2. header title을 props로 전달하는 로직을 추가했습니다.
- 각 페이지에 대한 타이틀이 header에 있어야 사용자가 해당 페이지의 기능을 보다 쉽게 이해할 수 있다고 판단하여, 페이지의 이름을 title로 설정했습니다.
- 모바일 웹의 경우, h1태그의 기본 글자크기가 크기때문에 24px로 고정시켰습니다.