### PR TITLE
feat: checkPage, backgroundPage UI 변경 및 header 메뉴 버튼 UI 변경

### DIFF
--- a/src/Common/Header/Header.styled.ts
+++ b/src/Common/Header/Header.styled.ts
@@ -45,7 +45,7 @@ export const menuButton = styled.button`
   height: 80px;
   position: absolute;
   right: 0;
-  background-color: salmon;
+  background-color: #5cffd1;
   border: 0;
   border-radius: 10px 10px 10px 10px;
   z-index: 2;
@@ -75,7 +75,7 @@ export const menuButton = styled.button`
     left: 0;
     width: 100%;
     height: 4px;
-    background-color: #fff;
+    background-color: black;
     border-radius: 4px;
   }
 
@@ -116,6 +116,7 @@ export const headerUl = styled.ul<{ menuVisible: boolean }>`
   @keyframes dropdown {
     0% {
       transform: translateY(-100%);
+      display: none;
     }
     100% {
       transform: translateY(0);
@@ -130,6 +131,7 @@ export const headerUl = styled.ul<{ menuVisible: boolean }>`
     100% {
       transform: translateY(-100%);
       background-color: none;
+      display: none;
     }
   }
 
@@ -150,7 +152,7 @@ export const headerUl = styled.ul<{ menuVisible: boolean }>`
       display: block;
       width: 0;
       height: 2px;
-      background-color: salmon;
+      background-color: #5cffd1;
       transition: width 0.2s ease-out;
     }
 

--- a/src/Common/Header/Header.tsx
+++ b/src/Common/Header/Header.tsx
@@ -7,17 +7,14 @@ interface HeaderProps {
 }
 
 const Header: React.FC<HeaderProps> = ({ title }) => {
-  const [menuText, setMenuText] = useState("메뉴 펼치기");
   const [clickMenu, setClickMenu] = useState(false);
   const [menuDefault, setMenuDefault] = useState(false);
 
   const handleMenu = () => {
     if (clickMenu === false) {
       setClickMenu(true);
-      setMenuText("메뉴 접기");
     } else {
       setClickMenu(false);
-      setMenuText("메뉴 펼치기");
     }
     setMenuDefault(true);
   };

--- a/src/Pages/BackgroundPage/BackgroundPage.styled.ts
+++ b/src/Pages/BackgroundPage/BackgroundPage.styled.ts
@@ -10,6 +10,46 @@ export const backgroundDiv = styled.div`
   text-align: center;
   justify-content: center;
   align-items: center;
+
+  h1 {
+    text-shadow: 10px 10px 10px #5cffd1;
+  }
+
+  button {
+    border: 1px solid #5cffd1;
+    border-radius: 10px;
+    box-sizing: border-box;
+    padding: 5px;
+    cursor: pointer;
+    outline: none;
+
+    &:hover {
+      background-color: #00c3c1;
+      color: #f2f2f2;
+      transition: 0.5s;
+    }
+  }
+`;
+
+export const controllSection = styled.section`
+  display: flex;
+  justify-content: center;
+  gap: 20px;
+
+  button {
+    border: 1px solid #5cffd1;
+    border-radius: 10px;
+    box-sizing: border-box;
+    padding: 5px;
+    cursor: pointer;
+    outline: none;
+
+    &:hover {
+      background-color: #00c3c1;
+      color: #f2f2f2;
+      transition: 0.5s;
+    }
+  }
 `;
 
 export const textImg = styled.img`

--- a/src/Pages/BackgroundPage/BackgroundPage.tsx
+++ b/src/Pages/BackgroundPage/BackgroundPage.tsx
@@ -41,8 +41,11 @@ export default function BackgroundPage() {
         <section style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', marginBottom: 20 }}>
           <HexColorPicker color={color} onChange={setColor} />
         </section>
-        <button onClick={handleColorArray}>색 더하기</button>
-        <button onClick={reverseColorArray}>색 반전</button>
+        <S.controllSection>
+          <button onClick={handleColorArray}>색 더하기</button>
+          <button onClick={reverseColorArray}>색 반전</button>
+        </S.controllSection>
+
 
         <Button previousLink='/' nextLink='/info' />
 

--- a/src/Pages/CheckPage/CheckPage.styled.ts
+++ b/src/Pages/CheckPage/CheckPage.styled.ts
@@ -10,7 +10,7 @@ export const textSection = styled.section`
   max-width: 400px;
   margin: auto;
   border-radius: 10px;
-  border: 1px solid transparent;
+  border: 1px solid #5cffd1;
   position: relative;
   background-color: #ffff;
 
@@ -26,26 +26,42 @@ export const textSection = styled.section`
   }
 `;
 
-export const guideImg = styled.img`
-  transition: opacity 1s ease-in-out;
-`;
+export const guideImg = styled.img``;
 
 export const BtnSection = styled.section`
   margin-top: 20px;
   display: flex;
   justify-content: center;
   gap: 20px;
-`;
 
-export const falseText = styled.section`
-  max-width: 300px;
-  margin: auto;
-  border-radius: 10px;
-  border: 1px solid transparent;
-  background-color: #ffff;
+  button {
+    width: 90px;
+    height: 30px;
+    border: 1px solid #5cffd1;
+    border-radius: 10px;
+    cursor: pointer;
+
+    &:hover {
+      background-color: #00c3c1;
+      color: #f2f2f2;
+      transition: 0.7s;
+    }
+  }
 `;
 
 export const answerAgian = styled.button`
-  border: 0;
-  background-color: transparent;
+  max-width: 300px;
+  margin: auto;
+  display: block;
+  box-sizing: border-box;
+  border: 1px solid #5cffd1;
+  border-radius: 10px;
+  padding: 10px;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #00c3c1;
+    color: #f2f2f2;
+    transition: 0.7s;
+  }
 `;

--- a/src/Pages/CheckPage/CheckPage.tsx
+++ b/src/Pages/CheckPage/CheckPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import { useState } from 'react'
 import { userState, nameState } from '../recoil'
 import { useRecoilValue } from 'recoil'
 import { guide1, guide2, guide3 } from '../../img/img'
@@ -56,9 +56,7 @@ export default function CheckPage() {
       </Link>
 
       {falseText &&
-        <S.falseText>
-          <S.answerAgian onClick={handleTrue}>생각해보니 맞는 것 같아!</S.answerAgian>
-        </S.falseText>
+        <S.answerAgian onClick={handleTrue}>생각해보니 맞는 것 같아!</S.answerAgian>
       }
 
       {defaultText &&


### PR DESCRIPTION
# 1. checkPage의 UI를 변경했습니다.
- 다른 페이지와의 통일성을 갖도록 버튼과 말주머니의 boder 색을 변경하고, 버튼의 형태를 보다 클릭하기 쉽도록 padding값을 부여하여 변경했습니다.
- 해당 페이지의 경우, 수령이 받는 페이지이기 때문에 header와 footer 태그는 따로 추가하진 않았습니다.

# 2. backgroundPage의 색상 선택 버튼 UI를 변경했습니다.
- 기존의 crome이 제공하는 UI는 가시성은 물론 클릭할 수 있는 면적 또한 적기 때문에, 버튼들을 묶는 section태그를 추가하여 display: flex로 변경했습니다.

# 3. header 메뉴 버튼의 색상을 변경했습니다.
- 다른 페이지들과의 통일성을 위해, 버튼과 hover했을때 li태그의 밑줄 색들을 민트색으로 변경했습니다.

# 4. 향후 작업 내용
- header 메뉴 버튼이 동적으로 변경될 수 있는 기능 추가
- 모든 페이지의 div태그 공용 컴퍼넌트화