### PR TITLE
feat : 공용 레이아웃 추가 및 globalStyle에 웹폰트 적용

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,3 @@
-import React, { useState } from 'react';
 import { HashRouter, Route, Routes } from 'react-router-dom';
 import FirstPage from './Pages/FirstPage/FirstPage';
 import InfoPage from './Pages/InfoPage/InfoPage';
@@ -25,6 +24,15 @@ function App() {
     width: 100%;
     height: 100%;
     word-break: keep-all;
+    font-family: 'Cafe24Dongdong';
+
+    @font-face {
+    font-family: 'Cafe24Dongdong';
+    src: url('https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_twelve@1.1/Cafe24Dongdong.woff') format('woff');
+    font-weight: normal;
+    font-style: normal;
+    }
+
   }
 
   body::before {

--- a/src/Common/Button/Button.styled.ts
+++ b/src/Common/Button/Button.styled.ts
@@ -16,6 +16,8 @@ export const btnButton = styled.button`
   border: 1px solid #5cffd1;
   border-radius: 10px;
   cursor: pointer;
+  font-family: inherit;
+  font-size: 20px;
 
   &:hover {
     background-color: #00c3c1;

--- a/src/Common/Header/Header.styled.ts
+++ b/src/Common/Header/Header.styled.ts
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { Link } from 'react-router-dom';
+import { guide2 } from '../../img/img';
 
 export const headerWrapper = styled.div`
   display: flex;
@@ -31,9 +32,40 @@ export const header = styled.header`
   }
 `;
 
+export const homeBtn = styled(Link)`
+  width: 70px;
+  position: relative;
+  background-image: url(${guide2});
+  background-position: center;
+  background-size: cover;
+  :hover {
+    & {
+      visibility: visible;
+      opacity: 1;
+    }
+  }
+`;
+
+export const hoveredText = styled.p`
+  height: 100%;
+  visibility: visible;
+  background-color: #f2f2f2;
+  border-radius: 6px;
+  margin: auto;
+  box-sizing: border-box;
+  padding: 10px;
+  position: absolute;
+  z-index: 3;
+  top: 0;
+  opacity: 0;
+  transition: opacity 0.3s;
+  color: black;
+`;
+
 export const menuContainer = styled.section`
   height: 80px;
   display: flex;
+
   @media (max-width: 500px) {
     width: 80px;
     flex-direction: column;
@@ -49,6 +81,7 @@ export const menuButton = styled.button`
   border: 0;
   border-radius: 10px 10px 10px 10px;
   z-index: 2;
+  cursor: pointer;
 
   :focus {
     border: 0;
@@ -141,8 +174,9 @@ export const headerUl = styled.ul<{ menuVisible: boolean }>`
       : 'scrollup 0.4s ease-in forwards'};
 
   & {
-    padding: 0;
     position: absolute;
+    box-sizing: border-box;
+    padding: 10px 0;
     top: 65px;
     right: 0;
     width: 80px;

--- a/src/Common/Header/Header.tsx
+++ b/src/Common/Header/Header.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import * as S from './Header.styled';
-import { guide2 } from '../../img/img';
 
 interface HeaderProps {
   title: string;
@@ -19,15 +18,17 @@ const Header: React.FC<HeaderProps> = ({ title }) => {
     setMenuDefault(true);
   };
 
+
   return (
     <>
       <S.headerWrapper>
         <S.header>
-          <img src={guide2} alt="" />
+          <S.homeBtn to="/">
+            <S.hoveredText>Welcome 페이지로 이동하기</S.hoveredText></S.homeBtn>
           <h1>{title}</h1>
           <S.menuContainer>
             <S.menuButton onClick={handleMenu}>
-              <div className="menu-trigger">
+              <div className={`menu-trigger ${clickMenu ? 'active-1' : ''}`}>
                 <span></span>
                 <span></span>
                 <span></span>

--- a/src/Common/Modal/Modal.tsx
+++ b/src/Common/Modal/Modal.tsx
@@ -1,5 +1,4 @@
 import { useEffect, MouseEvent } from 'react';
-import React from 'react';
 import * as S from './Modal.styled';
 import { ReactNode } from 'react';
 

--- a/src/Common/Wrapper/Wrapper.styled.ts
+++ b/src/Common/Wrapper/Wrapper.styled.ts
@@ -1,0 +1,41 @@
+import styled from 'styled-components';
+
+export const commonDiv = styled.div`
+  width: auto;
+  height: auto;
+  min-height: calc(100% - 200px);
+  padding-bottom: 200px;
+  margin: auto;
+  margin-top: 80px;
+  text-align: center;
+  justify-content: center;
+  align-items: center;
+
+  h1 {
+    text-shadow: 10px 10px 10px #5cffd1;
+  }
+
+  span {
+    font-style: italic;
+    box-sizing: border-box;
+    box-shadow: inset 0 -0.6em #5cffd1;
+    border-bottom: 2px solid #00c3c1;
+  }
+
+  button {
+    border: 1px solid #5cffd1;
+    border-radius: 10px;
+    box-sizing: border-box;
+    padding: 5px;
+    cursor: pointer;
+    outline: none;
+    font-family: inherit;
+    font-size: 20px;
+
+    &:hover {
+      background-color: #00c3c1;
+      color: #f2f2f2;
+      transition: 0.5s;
+    }
+  }
+`;

--- a/src/Common/Wrapper/Wrapper.tsx
+++ b/src/Common/Wrapper/Wrapper.tsx
@@ -1,0 +1,15 @@
+import React, { ReactNode } from 'react'
+import * as S from './Wrapper.styled'
+
+interface GlobalLayoutProps {
+  children: ReactNode;
+}
+
+export default function Wrapper({ children }: GlobalLayoutProps) {
+
+  return (
+    <S.commonDiv>
+      {children}
+    </S.commonDiv>
+  )
+}

--- a/src/Pages/BackgroundPage/BackgroundPage.styled.ts
+++ b/src/Pages/BackgroundPage/BackgroundPage.styled.ts
@@ -1,36 +1,5 @@
 import styled from 'styled-components';
 
-export const backgroundDiv = styled.div`
-  max-width: 800px;
-  height: auto;
-  min-height: calc(100% - 200px);
-  padding-bottom: 200px;
-  margin: auto;
-  margin-top: 80px;
-  text-align: center;
-  justify-content: center;
-  align-items: center;
-
-  h1 {
-    text-shadow: 10px 10px 10px #5cffd1;
-  }
-
-  button {
-    border: 1px solid #5cffd1;
-    border-radius: 10px;
-    box-sizing: border-box;
-    padding: 5px;
-    cursor: pointer;
-    outline: none;
-
-    &:hover {
-      background-color: #00c3c1;
-      color: #f2f2f2;
-      transition: 0.5s;
-    }
-  }
-`;
-
 export const controllSection = styled.section`
   display: flex;
   justify-content: center;

--- a/src/Pages/BackgroundPage/BackgroundPage.tsx
+++ b/src/Pages/BackgroundPage/BackgroundPage.tsx
@@ -7,6 +7,7 @@ import { backgroundState } from '../recoil';
 import Guide from '../../Common/GuideSection/GuideSection';
 import Header from '../../Common/Header/Header';
 import Footer from '../../Common/Footer/Footer';
+import Wrapper from '../../Common/Wrapper/Wrapper';
 
 import * as S from './BackgroundPage.styled'
 
@@ -34,8 +35,8 @@ export default function BackgroundPage() {
     <>
       <GlobalStyles />
       <Header title='Background Page' />
-      <S.backgroundDiv >
-        <h1>편지의 배경을 선택하는 페이지 입니다.</h1>
+      <Wrapper>
+        <h1> 편지의 배경을 선택하는 페이지 입니다.</h1>
         <Guide title='편지지의 그라데이션 배경을 설정하는 방법' step1='1. 원하시는 색을 클릭하고 색 더하기를 눌러보세요' step2='2. 색상의 반전을 원하시면 색 반전 버튼을 클릭하시면 됩니다.'
           step3='* 그라데이션은 두 개의 색을 결합한 디자인을 의미하며 색을 추가하면 기존의 색을 밀어 올리는 방식으로 제작됩니다.' />
         <section style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', marginBottom: 20 }}>
@@ -45,11 +46,8 @@ export default function BackgroundPage() {
           <button onClick={handleColorArray}>색 더하기</button>
           <button onClick={reverseColorArray}>색 반전</button>
         </S.controllSection>
-
-
         <Button previousLink='/' nextLink='/info' />
-
-      </S.backgroundDiv>
+      </Wrapper>
       <Footer />
     </>
   )

--- a/src/Pages/BgmPage/BgmPage.styled.ts
+++ b/src/Pages/BgmPage/BgmPage.styled.ts
@@ -33,15 +33,6 @@ export const guideTitle = styled.h2`
   margin: 0;
 `;
 
-export const bgmDiv = styled.div`
-  width: auto;
-  margin-top: 80px;
-  height: auto;
-  min-height: calc(100% - 200px);
-  padding-bottom: 200px;
-  text-align: center;
-`;
-
 export const bgmSection = styled.section`
   display: block;
   max-width: 400px;

--- a/src/Pages/BgmPage/BgmPage.tsx
+++ b/src/Pages/BgmPage/BgmPage.tsx
@@ -6,12 +6,12 @@ import Modal from '../../Common/Modal/Modal'
 import Button from '../../Common/Button/Button'
 import Header from '../../Common/Header/Header'
 import Footer from '../../Common/Footer/Footer'
+import Wrapper from '../../Common/Wrapper/Wrapper'
 import { guide2 } from '../../img/img'
 import { guide3 } from '../../img/img'
 import * as S from './BgmPage.styled'
 import * as M from '../../Common/Modal/ModalBox.styled';
 import YouTube from 'react-youtube'
-import { url } from 'inspector'
 
 
 export default function BgmPage() {
@@ -82,16 +82,16 @@ export default function BgmPage() {
 
   return (
     <>
-      <Header title='BgmPage' />
-      <S.bgmDiv>
-        <h1>원하는 유튜브 bgm ID를 입력하는 페이지 입니다.</h1>
+      <Header title='BGM_Page' />
+      <Wrapper>
+        <h1>BGM을 등록하는 페이지 입니다.</h1>
         <S.bgmGuide>
           <S.pcGuide>
-            <S.guideTitle>1. PC버전으로 bgmID 입력하는 방법</S.guideTitle>
+            <S.guideTitle>1. PC버전으로 BGM ID 입력하는 방법</S.guideTitle>
             <p> - 페이지 상단에 있는 페이지 주소(URL)을 복사해서 입력란에 붙여주세요.</p>
           </S.pcGuide>
           <S.mobileGuide>
-            <S.guideTitle>2. 모바일 버전으로 bgmID입력하는 방법</S.guideTitle>
+            <S.guideTitle>2. 모바일 버전으로 BGM ID입력하는 방법</S.guideTitle>
             <p> - 영상 하단의 공유 버튼을 클릭한 후, 링크복사를 한 뒤, 입력란에 붙여주세요.</p>
           </S.mobileGuide>
         </S.bgmGuide>
@@ -116,8 +116,7 @@ export default function BgmPage() {
 
 
         <Button previousLink='/image' nextLink={handleEmty} />
-
-      </S.bgmDiv>
+      </Wrapper>
       {isModalOpen &&
         <Modal closeModal={closeModal}>
           <M.modalContainer style={{ backgroundImage: modalBackground, backgroundSize: 'cover', backgroundPosition: 'center center' }}>

--- a/src/Pages/FirstPage/FirstPage.styled.ts
+++ b/src/Pages/FirstPage/FirstPage.styled.ts
@@ -41,6 +41,7 @@ export const carouselController = styled.section`
     border: 0;
     background-color: transparent;
     font-size: 24px;
+    cursor: pointer;
   }
 
   @media (max-width: 500px) {

--- a/src/Pages/ImagePage/ImagePage.styled.ts
+++ b/src/Pages/ImagePage/ImagePage.styled.ts
@@ -1,14 +1,5 @@
 import styled from 'styled-components';
 
-export const ImageDiv = styled.div`
-  width: auto;
-  margin-top: 80px;
-  height: auto;
-  min-height: calc(100% - 200px);
-  padding-bottom: 200px;
-  text-align: center;
-`;
-
 export const DeleteBtn = styled.button`
   position: absolute;
   top: 0;

--- a/src/Pages/ImagePage/ImagePage.tsx
+++ b/src/Pages/ImagePage/ImagePage.tsx
@@ -7,6 +7,7 @@ import Button from '../../Common/Button/Button'
 import Guide from '../../Common/GuideSection/GuideSection';
 import Header from '../../Common/Header/Header';
 import Footer from '../../Common/Footer/Footer';
+import Wrapper from '../../Common/Wrapper/Wrapper';
 import 'react-responsive-carousel/lib/styles/carousel.min.css';
 
 
@@ -44,8 +45,8 @@ export default function ImagePage() {
   return (
     <>
       <Header title='ImagePage' />
-      <S.ImageDiv>
-        <h1>여러분들이 함께한 추억을 올리는 단계입니다.</h1>
+      <Wrapper>
+        <h1>편지에 추가할 사진을 올리는 단계입니다.</h1>
         <Guide title='이미지 업로드하는 방법' step1='- 파일선택 버튼을 클릭하여 원하시는 사진을 업로드 해주세요.' step2={null} step3={null}></Guide>
         <S.ImageInput type="file" multiple accept='image/*' onChange={handleImageChange} placeholder='사진을 올려주세요.' />
         <S.ImageSection style={{ display: handlingSection() }}>
@@ -59,9 +60,7 @@ export default function ImagePage() {
           </Carousel>
         </S.ImageSection>
 
-        <Button previousLink='/write' nextLink='/bgm' />
-
-      </S.ImageDiv>
+        <Button previousLink='/write' nextLink='/bgm' /></Wrapper>
       <Footer />
     </>
 

--- a/src/Pages/InfoPage/InfoPage.styled.ts
+++ b/src/Pages/InfoPage/InfoPage.styled.ts
@@ -1,14 +1,5 @@
 import { styled } from 'styled-components';
 
-export const InfoDiv = styled.div`
-  width: auto;
-  margin-top: 80px;
-  height: auto;
-  min-height: calc(100% - 200px);
-  padding-bottom: 200px;
-  text-align: center;
-`;
-
 export const InfoForm = styled.form`
   max-width: 400px;
   margin: auto;

--- a/src/Pages/InfoPage/InfoPage.tsx
+++ b/src/Pages/InfoPage/InfoPage.tsx
@@ -7,6 +7,7 @@ import Guide from '../../Common/GuideSection/GuideSection';
 import Modal from '../../Common/Modal/Modal';
 import Header from '../../Common/Header/Header';
 import Footer from '../../Common/Footer/Footer';
+import Wrapper from '../../Common/Wrapper/Wrapper';
 import * as S from './InfoPage.styled';
 import * as M from '../../Common/Modal/ModalBox.styled';
 
@@ -52,7 +53,7 @@ export default function InfoPage() {
   return (
     <>
       <Header title='InfoPage' />
-      <S.InfoDiv>
+      <Wrapper>
         <h1>편지에 작성할 기본 정보들을 입력하는 단계입니다.</h1>
         <Guide title='발신자와 수신자 설정 방법' step1='1. 상단에 있는 칸에는 발신자 분의 성함을 입력해주세요.' step2='2. 수신 하단에 있는 칸에는 수신자 분의 성함을 입력해주세요.'
           step3='*해당 정보는 필수 정보이기에 꼭 입력해주세요!!' ></Guide>
@@ -80,9 +81,7 @@ export default function InfoPage() {
           </label>
           <Button previousLink='/background' nextLink={handleEmty} />
         </S.InfoForm>
-
-
-      </S.InfoDiv>
+      </Wrapper>
       {isModalOpen &&
         <Modal closeModal={closeModal}>
           <M.modalContainer>

--- a/src/Pages/WrittingPage/WrittingPage.tsx
+++ b/src/Pages/WrittingPage/WrittingPage.tsx
@@ -6,6 +6,7 @@ import Button from '../../Common/Button/Button'
 import Guide from '../../Common/GuideSection/GuideSection';
 import Header from '../../Common/Header/Header';
 import Footer from '../../Common/Footer/Footer';
+import Wrapper from '../../Common/Wrapper/Wrapper';
 import Modal from '../../Common/Modal/Modal';
 import * as M from '../../Common/Modal/ModalBox.styled';
 import * as S from './Wrtiting.styled';
@@ -56,6 +57,7 @@ export default function WrittingPage() {
   };
 
   const writingFormStyle = {
+    backgroundColor: '#f2f2f2',
     backgroundImage: `url(${selectImage})`,
     backgroundRepeat: 'no-repeat',
   }
@@ -67,12 +69,12 @@ export default function WrittingPage() {
   return (
     <>
       <Header title='WritingPage' />
-      <S.WritingDiv>
+      <Wrapper>
         <link
           href={`https://fonts.googleapis.com/css?family=${font}`}
           rel="stylesheet"
         />
-        <h1>편지에 작성할 편지내용을 입력하는 단계입니다.</h1>
+        <h1>편지를 작성하는 단계입니다.</h1>
         <Guide title='편지 작성 가이드' step1='1. 원하시는 글자의 폰트와 크기, 편지지의 배경을 선택해주세요.' step2='2. 폰트 설정 숨기기 버튼을 누르시고 하단의 편지지에 편지를 작성하시면 됩니다.' step3='*글자 수에는 제한은 없지만, 글자 크기는 되도록 24px로 하시는 것을 권장드립니다.'></Guide>
 
         <S.hiddingBtn onClick={handleSettingHide}>{hide}</S.hiddingBtn>
@@ -117,8 +119,7 @@ export default function WrittingPage() {
         </S.WritingForm>
 
         <Button previousLink='/info' nextLink={handleEmty} />
-
-      </S.WritingDiv>
+      </Wrapper>
       {isModalOpen &&
         <Modal closeModal={closeModal}>
           <M.modalContainer>

--- a/src/Pages/WrittingPage/Wrtiting.styled.ts
+++ b/src/Pages/WrittingPage/Wrtiting.styled.ts
@@ -1,14 +1,5 @@
 import { styled } from 'styled-components';
 
-export const WritingDiv = styled.div`
-  width: auto;
-  margin-top: 80px;
-  height: auto;
-  min-height: calc(100% - 200px);
-  padding-bottom: 200px;
-  text-align: center;
-`;
-
 export const hiddingBtn = styled.button`
   margin-bottom: 20px;
   border: 1px solid #5cffd1;

--- a/src/font.d.ts
+++ b/src/font.d.ts
@@ -1,0 +1,2 @@
+declare module '*.ttf';
+declare module '*.woff2';


### PR DESCRIPTION
# 1. 페이지를 감싸는 레이아웃을 공용 컴퍼넌트에 추가했습니다.
- welcome페이지를 제외한 나머지 편지 작성 페이지들의 최상단 div태그가 전부 같아 이를 공용 컴퍼넌트로 분리했습니다.
- 그 결과, 각 페이지의 styled-compnent가 상당히 간단해지고, 코드 재사용율이 상당히 높아졌습니다.

# 2. globalStyle에 웹폰트를 적용했습니다.
- 기본 폰트는 너무 성의없어 보이기에, 이를 보완하고자 웹폰트를 적용했습니다.
- 처음에는 font폴더를 따로 만들고, 웹폰트를 다운받아 사용하려 했으나, 리렌더링에서 발생하는 딜레이가 심각했습니다.
- 이를 해결하고자, 웹 서버에서 직접 받아오는 방식으로 전환하니, 리렌더링 딜레이가 거의 생기지 않았습니다.

# 3. header에 welcomePage로 이동하는 링크를 추가했습니다.
- header의 가장 왼쪽에 위치한 아이콘의 용도가 불명확했고, 사용자가 welcomePage를 많이 이용할 것이라 판단하여, 해당 아이콘에 welcomePage로 이동하는 링크를 추가했습니다.
- 아이콘을 호버할 경우, 'welcomePage로 이동하기'라는 p태그가 나타나는 로직을 구현했습니다.