### PR TITLE
feat: BgmPage 영상 초기값 변경 및 checkPage 버튼 UI 변경

### DIFF
--- a/src/Pages/BgmPage/BgmPage.tsx
+++ b/src/Pages/BgmPage/BgmPage.tsx
@@ -71,7 +71,7 @@ export default function BgmPage() {
     if (videoID !== null) {
       setVideoId(videoID);
     } else {
-      setVideoId('BDY7VAxGb24');
+      setVideoId('');
     }
   }
 

--- a/src/Pages/CheckPage/CheckPage.styled.ts
+++ b/src/Pages/CheckPage/CheckPage.styled.ts
@@ -39,6 +39,8 @@ export const BtnSection = styled.section`
     height: 30px;
     border: 1px solid #5cffd1;
     border-radius: 10px;
+    font-family: inherit;
+    font-size: inherit;
     cursor: pointer;
 
     &:hover {


### PR DESCRIPTION
# 1. BgmPage의 영상 초기값을 변경했습니다.
- 편지에 BGM을 넣고 싶지 않은 사용자도 있을 것을 고려하여, 페이지의 영상 초기값을 빈값으로 설정하여 재생되는 영상이 없게 변경했습니다.
- 빈값을 넘어갈 시, TestPage에 영상 section이 가려지도록 변경할 예정입니다.

# 2. checkPage의 버튼 UI를 다른 페이지의 버튼과 동일하게 변경했습니다.